### PR TITLE
Add Before hooks code generation

### DIFF
--- a/generator/templates/model.tgo
+++ b/generator/templates/model.tgo
@@ -41,6 +41,15 @@ func New{{.StoreName}}(db *sql.DB) *{{.StoreName}} {
 // Insert inserts a {{.Name}} in the database. A non-persisted object is
 // required for this operation.
 func (s *{{.StoreName}}) Insert(record *{{.Name}}) error {
+        {{if .Events.Has "BeforeSave"}}
+        if err := record.BeforeSave(); err != nil {
+                return err
+        }
+        {{end}}
+        {{if .Events.Has "BeforeInsert"}}
+        if err := record.BeforeInsert(); err != nil {
+        }
+        {{end}}
 	return s.Store.Insert(record)
 }
 
@@ -51,12 +60,41 @@ func (s *{{.StoreName}}) Insert(record *{{.Name}}) error {
 // Only writable records can be updated. Writable objects are those that have
 // been just inserted or retrieved using a query with no custom select fields.
 func (s *{{.StoreName}}) Update(record *{{.Name}}, cols ...kallax.SchemaField) (int64, error) {
+        {{if .Events.Has "BeforeSave"}}
+        if err := record.BeforeSave(); err != nil {
+                return 0, err
+        }
+        {{end}}
+        {{if .Events.Has "BeforeUpdate"}}
+        if err := record.BeforeUpdate(); err != nil {
+                return 0, err
+        }
+        {{end}}
 	return s.Store.Update(record, cols...)
 }
 
 // Save inserts the object if the record is not persisted, otherwise it updates
 // it. Same rules of Update and Insert apply depending on the case.
 func (s *{{.StoreName}}) Save(record *{{.Name}}) (updated bool,  err error) {
+        {{if .Events.Has "BeforeSave"}}
+        if err := record.BeforeSave(); err != nil {
+                return false, err
+        }
+        {{end}}
+        {{if .Events.Has "BeforeInsert"}}
+        if !record.IsPersisted() {
+                if err := record.BeforeInsert(); err != nil {
+                        return false, err
+                }
+        }
+        {{end}}
+        {{if .Events.Has "BeforeUpdate"}}
+        if record.IsPersisted() {
+                if err := record.BeforeUpdate(); err != nil {
+                        return false, err
+                }
+        }
+        {{end}}
 	return s.Store.Save(record)
 }
 


### PR DESCRIPTION
After hooks are not being generated because of a very small problem: we need transactions first.