### PR TITLE
Separated test suites, with separated schemas

### DIFF
--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
-	"testing"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -17,6 +16,52 @@ var (
 	password         = envOrDefault("DBPASS", "testing")
 )
 
+type BaseTestSuite struct {
+	suite.Suite
+	db          *sql.DB
+	initQueries []string
+}
+
+func (s *BaseTestSuite) SetupSuite() {
+	db, err := sql.Open(
+		"postgres",
+		fmt.Sprintf(connectionString, user, password, host, database),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("It was unable to connect to the DB.\n%s\n", err))
+	}
+
+	s.db = db
+
+	if len(s.initQueries) > 0 {
+		s.QuerySucceed(s.initQueries...)
+	}
+}
+
+func (s *BaseTestSuite) TearDownSuite() {
+	s.QuerySucceed(
+		fmt.Sprintf(`DROP SCHEMA %s CASCADE;`, database),
+		fmt.Sprintf(`CREATE SCHEMA %s;`, database),
+	)
+	s.db.Close()
+}
+
+func (s *BaseTestSuite) QuerySucceed(queries ...string) {
+	for _, query := range queries {
+		res, err := s.db.Exec(query)
+		s.NotNil(res, "Resulset should not be empty")
+		s.Nil(err, fmt.Sprintf("%s\nshould succeed but it failed.\n%s\n", query, err))
+	}
+}
+
+func (s *BaseTestSuite) QueryFails(queries ...string) {
+	for _, query := range queries {
+		res, err := s.db.Exec(query)
+		s.Nil(res, "Resulset should be empty but it was not")
+		s.NotNil(err, fmt.Sprintf("%s\nshould fail but it succeed", query))
+	}
+}
+
 func envOrDefault(key string, def string) string {
 	v := os.Getenv(key)
 	if v == "" {
@@ -24,41 +69,4 @@ func envOrDefault(key string, def string) string {
 	}
 
 	return v
-}
-
-func TestHijackSuite(t *testing.T) {
-	suite.Run(t, new(CommonSuite))
-}
-
-type CommonSuite struct {
-	suite.Suite
-	db *sql.DB
-}
-
-func (s *CommonSuite) SetupSuite() {
-	db, err := sql.Open(
-		"postgres",
-		fmt.Sprintf(connectionString, user, password, host, database),
-	)
-	s.Nil(err)
-	s.NotNil(db)
-	s.db = db
-
-	res, err := s.db.Exec(`DROP TABLE IF EXISTS testing`)
-	s.NotNil(res)
-	s.Nil(err)
-
-	res, err = s.db.Exec(`CREATE TABLE testing (id uuid primary key)`)
-	s.NotNil(res)
-	s.Nil(err)
-}
-
-func (s *CommonSuite) TearDownSuite() {
-	res, err := s.db.Exec("DROP TABLE testing")
-	s.NotNil(res)
-	s.Nil(err)
-
-	res, err = s.db.Exec("DROP TABLE _THIS_TABLE_DOES_NOT_EXIST")
-	s.Nil(res)
-	s.NotNil(err)
 }

--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -9,11 +9,20 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+var (
+	connectionString = "postgres://%s:%s@%s/%s?sslmode=disable"
+	host             = envOrDefault("DBHOST", "0.0.0.0:5432")
+	database         = envOrDefault("DBNAME", "testing")
+	user             = envOrDefault("DBUSER", "testing")
+	password         = envOrDefault("DBPASS", "testing")
+)
+
 func envOrDefault(key string, def string) string {
 	v := os.Getenv(key)
 	if v == "" {
-		v = def
+		return def
 	}
+
 	return v
 }
 
@@ -27,12 +36,10 @@ type CommonSuite struct {
 }
 
 func (s *CommonSuite) SetupSuite() {
-	db, err := sql.Open("postgres", fmt.Sprintf(
-		"postgres://%s:%s@0.0.0.0:5432/%s?sslmode=disable",
-		envOrDefault("DBUSER", "testing"),
-		envOrDefault("DBPASS", "testing"),
-		envOrDefault("DBNAME", "testing"),
-	))
+	db, err := sql.Open(
+		"postgres",
+		fmt.Sprintf(connectionString, user, password, host, database),
+	)
 	s.Nil(err)
 	s.NotNil(db)
 	s.db = db

--- a/tests/connection_test.go
+++ b/tests/connection_test.go
@@ -1,0 +1,24 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestConnectionSuite(t *testing.T) {
+	suite.Run(t, new(ConnectionSuite))
+}
+
+type ConnectionSuite struct {
+	BaseTestSuite
+}
+
+func (s *ConnectionSuite) TestConnection() {
+	s.QuerySucceed(
+		`CREATE TABLE testing (id uuid primary key)`,
+		`DROP TABLE testing`,
+		`DROP TABLE IF EXISTS testing`,
+	)
+	s.QueryFails(`DROP TABLE _THIS_TABLE_DOES_NOT_EXIST`)
+}

--- a/tests/events_test.go
+++ b/tests/events_test.go
@@ -1,15 +1,26 @@
 package tests
 
 import (
-	"database/sql"
 	"errors"
+	"testing"
 
 	"github.com/stretchr/testify/suite"
 )
 
 type EventsSuite struct {
-	suite.Suite
-	db *sql.DB
+	BaseTestSuite
+}
+
+func TestEventsSuite(t *testing.T) {
+	schema := []string{
+		`CREATE TABLE event (
+			id uuid primary key,
+			checks JSON,
+			must_fail_before JSON,
+			must_fail_after JSON
+		)`,
+	}
+	suite.Run(t, &EventsSuite{BaseTestSuite{initQueries: schema}})
 }
 
 func (s *EventsSuite) TestEventsInsert() {

--- a/tests/events_test.go
+++ b/tests/events_test.go
@@ -1,8 +1,18 @@
 package tests
 
-import "errors"
+import (
+	"database/sql"
+	"errors"
 
-func (s *CommonSuite) TestEventsInsert() {
+	"github.com/stretchr/testify/suite"
+)
+
+type EventsSuite struct {
+	suite.Suite
+	db *sql.DB
+}
+
+func (s *EventsSuite) TestEventsInsert() {
 	store := NewEventsFixtureStore(s.db)
 
 	doc := NewEventsFixture()
@@ -14,7 +24,7 @@ func (s *CommonSuite) TestEventsInsert() {
 	}, doc.Checks)
 }
 
-func (s *CommonSuite) TestEventsUpdate() {
+func (s *EventsSuite) TestEventsUpdate() {
 	store := NewEventsFixtureStore(s.db)
 
 	doc := NewEventsFixture()
@@ -31,7 +41,7 @@ func (s *CommonSuite) TestEventsUpdate() {
 	}, doc.Checks)
 }
 
-func (s *CommonSuite) TestEventsUpdateError() {
+func (s *EventsSuite) TestEventsUpdateError() {
 	store := NewEventsFixtureStore(s.db)
 
 	doc := NewEventsFixture()
@@ -49,7 +59,7 @@ func (s *CommonSuite) TestEventsUpdateError() {
 	s.Equal(doc.MustFailBefore, err)
 }
 
-func (s *CommonSuite) TestEventsSaveOnInsert() {
+func (s *EventsSuite) TestEventsSaveOnInsert() {
 	store := NewEventsFixtureStore(s.db)
 
 	doc := NewEventsFixture()
@@ -62,7 +72,7 @@ func (s *CommonSuite) TestEventsSaveOnInsert() {
 	}, doc.Checks)
 }
 
-func (s *CommonSuite) TestEventsSaveOnUpdate() {
+func (s *EventsSuite) TestEventsSaveOnUpdate() {
 	store := NewEventsFixtureStore(s.db)
 
 	doc := NewEventsFixture()
@@ -78,7 +88,7 @@ func (s *CommonSuite) TestEventsSaveOnUpdate() {
 	}, doc.Checks)
 }
 
-func (s *CommonSuite) TestEventsSaveInsert() {
+func (s *EventsSuite) TestEventsSaveInsert() {
 	store := NewEventsSaveFixtureStore(s.db)
 
 	doc := NewEventsSaveFixture()
@@ -90,7 +100,7 @@ func (s *CommonSuite) TestEventsSaveInsert() {
 	}, doc.Checks)
 }
 
-func (s *CommonSuite) TestEventsSaveUpdate() {
+func (s *EventsSuite) TestEventsSaveUpdate() {
 	store := NewEventsSaveFixtureStore(s.db)
 
 	doc := NewEventsSaveFixture()
@@ -107,7 +117,7 @@ func (s *CommonSuite) TestEventsSaveUpdate() {
 	}, doc.Checks)
 }
 
-func (s *CommonSuite) TestEventsSaveSave() {
+func (s *EventsSuite) TestEventsSaveSave() {
 	store := NewEventsSaveFixtureStore(s.db)
 
 	doc := NewEventsSaveFixture()

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -1,15 +1,24 @@
 package tests
 
 import (
-	"database/sql"
+	"testing"
 
 	"github.com/src-d/go-kallax"
 	"github.com/stretchr/testify/suite"
 )
 
 type QuerySuite struct {
-	suite.Suite
-	db *sql.DB
+	BaseTestSuite
+}
+
+func TestQuerySuite(t *testing.T) {
+	schema := []string{
+		`CREATE TABLE query (
+			id uuid primary key,
+			foo varchar(10)
+		)`,
+	}
+	suite.Run(t, &QuerySuite{BaseTestSuite{initQueries: schema}})
 }
 
 func (s *QuerySuite) TestQueryFindById() {

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -1,8 +1,18 @@
 package tests
 
-import kallax "github.com/src-d/go-kallax"
+import (
+	"database/sql"
 
-func (s *CommonSuite) TestQueryFindById() {
+	"github.com/src-d/go-kallax"
+	"github.com/stretchr/testify/suite"
+)
+
+type QuerySuite struct {
+	suite.Suite
+	db *sql.DB
+}
+
+func (s *QuerySuite) TestQueryFindById() {
 	store := NewResultSetFixtureStore(s.db)
 
 	doc := NewResultSetFixture("bar")

--- a/tests/resultset_test.go
+++ b/tests/resultset_test.go
@@ -1,12 +1,19 @@
 package tests
 
 import (
+	"database/sql"
 	"errors"
 
-	kallax "github.com/src-d/go-kallax"
+	"github.com/src-d/go-kallax"
+	"github.com/stretchr/testify/suite"
 )
 
-func (s *CommonSuite) TestResultSetAll() {
+type ResulsetSuite struct {
+	suite.Suite
+	db *sql.DB
+}
+
+func (s *ResulsetSuite) TestResultSetAll() {
 	store := NewResultSetFixtureStore(s.db)
 	s.Nil(store.Insert(NewResultSetFixture("bar")))
 	s.Nil(store.Insert(NewResultSetFixture("foo")))
@@ -19,7 +26,7 @@ func (s *CommonSuite) TestResultSetAll() {
 	})
 }
 
-func (s *CommonSuite) TestResultSetAllInit() {
+func (s *ResulsetSuite) TestResultSetAllInit() {
 	store := NewResultSetInitFixtureStore(s.db)
 
 	s.Nil(store.Insert(NewResultSetInitFixture()))
@@ -35,7 +42,7 @@ func (s *CommonSuite) TestResultSetAllInit() {
 	})
 }
 
-func (s *CommonSuite) TestResultSetOne() {
+func (s *ResulsetSuite) TestResultSetOne() {
 	store := NewResultSetFixtureStore(s.db)
 	s.Nil(store.Insert(NewResultSetFixture("bar")))
 
@@ -47,7 +54,7 @@ func (s *CommonSuite) TestResultSetOne() {
 	})
 }
 
-func (s *CommonSuite) TestResultInitSetOne() {
+func (s *ResulsetSuite) TestResultInitSetOne() {
 	store := NewResultSetInitFixtureStore(s.db)
 
 	a := NewResultSetInitFixture()
@@ -63,7 +70,7 @@ func (s *CommonSuite) TestResultInitSetOne() {
 	})
 }
 
-func (s *CommonSuite) TestResultSetNextEmpty() {
+func (s *ResulsetSuite) TestResultSetNextEmpty() {
 	store := NewResultSetFixtureStore(s.db)
 
 	s.NotPanics(func() {
@@ -77,7 +84,7 @@ func (s *CommonSuite) TestResultSetNextEmpty() {
 	})
 }
 
-func (s *CommonSuite) TestResultSetNext() {
+func (s *ResulsetSuite) TestResultSetNext() {
 	store := NewResultSetFixtureStore(s.db)
 	s.Nil(store.Insert(NewResultSetFixture("bar")))
 
@@ -99,7 +106,7 @@ func (s *CommonSuite) TestResultSetNext() {
 	})
 }
 
-func (s *CommonSuite) TestResultSetInitNext() {
+func (s *ResulsetSuite) TestResultSetInitNext() {
 	store := NewResultSetInitFixtureStore(s.db)
 	s.Nil(store.Insert(NewResultSetInitFixture()))
 
@@ -117,7 +124,7 @@ func (s *CommonSuite) TestResultSetInitNext() {
 	})
 }
 
-func (s *CommonSuite) TestResultSetForEach() {
+func (s *ResulsetSuite) TestResultSetForEach() {
 	store := NewResultSetFixtureStore(s.db)
 	s.Nil(store.Insert(NewResultSetFixture("bar")))
 	s.Nil(store.Insert(NewResultSetFixture("foo")))
@@ -135,7 +142,7 @@ func (s *CommonSuite) TestResultSetForEach() {
 	})
 }
 
-func (s *CommonSuite) TestResultSetInitForEach() {
+func (s *ResulsetSuite) TestResultSetInitForEach() {
 	store := NewResultSetInitFixtureStore(s.db)
 	s.Nil(store.Insert(NewResultSetInitFixture()))
 	s.Nil(store.Insert(NewResultSetInitFixture()))
@@ -155,7 +162,7 @@ func (s *CommonSuite) TestResultSetInitForEach() {
 	})
 }
 
-func (s *CommonSuite) TestResultSetForEachStop() {
+func (s *ResulsetSuite) TestResultSetForEachStop() {
 	store := NewResultSetFixtureStore(s.db)
 	s.Nil(store.Insert(NewResultSetFixture("bar")))
 	s.Nil(store.Insert(NewResultSetFixture("foo")))
@@ -173,7 +180,7 @@ func (s *CommonSuite) TestResultSetForEachStop() {
 	})
 }
 
-func (s *CommonSuite) TestResultSetForEachError() {
+func (s *ResulsetSuite) TestResultSetForEachError() {
 	store := NewResultSetFixtureStore(s.db)
 	s.Nil(store.Insert(NewResultSetFixture("bar")))
 	s.Nil(store.Insert(NewResultSetFixture("foo")))

--- a/tests/resultset_test.go
+++ b/tests/resultset_test.go
@@ -1,16 +1,25 @@
 package tests
 
 import (
-	"database/sql"
 	"errors"
+	"testing"
 
 	"github.com/src-d/go-kallax"
 	"github.com/stretchr/testify/suite"
 )
 
 type ResulsetSuite struct {
-	suite.Suite
-	db *sql.DB
+	BaseTestSuite
+}
+
+func TestResulsetSuite(t *testing.T) {
+	schema := []string{
+		`CREATE TABLE resultset (
+			id uuid primary key,
+			foo varchar(10)
+		)`,
+	}
+	suite.Run(t, &ResulsetSuite{BaseTestSuite{initQueries: schema}})
 }
 
 func (s *ResulsetSuite) TestResultSetAll() {

--- a/tests/schema_test.go
+++ b/tests/schema_test.go
@@ -1,34 +1,44 @@
 package tests
 
-import "reflect"
+import (
+	"database/sql"
+	"reflect"
 
-func (s *CommonSuite) TestSchemaBasicField() {
+	"github.com/stretchr/testify/suite"
+)
+
+type SchemaSuite struct {
+	suite.Suite
+	db *sql.DB
+}
+
+func (s *SchemaSuite) TestSchemaBasicField() {
 	s.Equal("string", Schema.SchemaFixture.String)
 }
 
-func (s *CommonSuite) TestSchemaRanamedField() {
+func (s *SchemaSuite) TestSchemaRanamedField() {
 	s.Equal("int", Schema.SchemaFixture.Int)
 }
 
-func (s *CommonSuite) TestSchemaInlineField() {
+func (s *SchemaSuite) TestSchemaInlineField() {
 	schema := reflect.ValueOf(Schema.SchemaFixture)
 	field := reflect.Indirect(schema).FieldByName("Inline")
 	s.True(field.IsValid())
 }
 
-func (s *CommonSuite) TestSchemaMapsOfString() {
+func (s *SchemaSuite) TestSchemaMapsOfString() {
 	schema := reflect.ValueOf(Schema.SchemaFixture)
 	field := reflect.Indirect(schema).FieldByName("MapOfString")
 	s.True(field.IsValid())
 }
 
-func (s *CommonSuite) TestSchemaMapOfSomeType() {
+func (s *SchemaSuite) TestSchemaMapOfSomeType() {
 	schema := reflect.ValueOf(Schema.SchemaFixture)
 	field := reflect.Indirect(schema).FieldByName("MapOfSomeType")
 	s.True(field.IsValid())
 }
 
-func (s *CommonSuite) TestSchemaMapOfInterface() {
+func (s *SchemaSuite) TestSchemaMapOfInterface() {
 	schema := reflect.ValueOf(Schema.SchemaFixture)
 	field := reflect.Indirect(schema).FieldByName("MapOfInterface")
 	s.True(field.IsValid())

--- a/tests/schema_test.go
+++ b/tests/schema_test.go
@@ -1,15 +1,18 @@
 package tests
 
 import (
-	"database/sql"
 	"reflect"
+	"testing"
 
 	"github.com/stretchr/testify/suite"
 )
 
 type SchemaSuite struct {
-	suite.Suite
-	db *sql.DB
+	BaseTestSuite
+}
+
+func TestSchemaSuite(t *testing.T) {
+	suite.Run(t, new(SchemaSuite))
 }
 
 func (s *SchemaSuite) TestSchemaBasicField() {

--- a/tests/store_test.go
+++ b/tests/store_test.go
@@ -1,16 +1,40 @@
 package tests
 
 import (
-	"database/sql"
+	"testing"
 	"time"
 
-	"github.com/src-d/go-kallax"
+	kallax "github.com/src-d/go-kallax"
 	"github.com/stretchr/testify/suite"
 )
 
+func TestStoreSuite(t *testing.T) {
+	schema := []string{
+		`CREATE TABLE store_construct (
+			id uuid primary key,
+			foo varchar(10)
+		)`,
+		`CREATE TABLE store (
+			id uuid primary key,
+			foo varchar(10)
+		)`,
+		`CREATE TABLE store_new (
+			id uuid primary key,
+			foo varchar(10),
+			bar varchar(10)
+		)`,
+		`CREATE TABLE query (
+			id uuid primary key,
+			name varchar(10),
+			start timestamp,
+			_end timestamp
+		)`,
+	}
+	suite.Run(t, &StoreSuite{BaseTestSuite{initQueries: schema}})
+}
+
 type StoreSuite struct {
-	suite.Suite
-	db *sql.DB
+	BaseTestSuite
 }
 
 func (s *StoreSuite) TestStoreNew() {

--- a/tests/store_test.go
+++ b/tests/store_test.go
@@ -1,23 +1,30 @@
 package tests
 
 import (
+	"database/sql"
 	"time"
 
-	kallax "github.com/src-d/go-kallax"
+	"github.com/src-d/go-kallax"
+	"github.com/stretchr/testify/suite"
 )
 
-func (s *CommonSuite) TestStoreNew() {
+type StoreSuite struct {
+	suite.Suite
+	db *sql.DB
+}
+
+func (s *StoreSuite) TestStoreNew() {
 	doc := NewStoreFixture()
 	s.False(doc.IsPersisted())
 	s.Len(doc.ID.String(), 24)
 }
 
-func (s *CommonSuite) TestStoreQuery() {
+func (s *StoreSuite) TestStoreQuery() {
 	q := NewStoreFixtureQuery()
 	s.NotNil(q)
 }
 
-func (s *CommonSuite) TestStoreFindAndCount() {
+func (s *StoreSuite) TestStoreFindAndCount() {
 	store := NewStoreFixtureStore(s.db)
 	s.Nil(store.Insert(NewStoreFixture()))
 	s.Nil(store.Insert(NewStoreFixture()))
@@ -32,7 +39,7 @@ func (s *CommonSuite) TestStoreFindAndCount() {
 	s.Equal(2, count)
 }
 
-func (s *CommonSuite) TestStoreMustFind() {
+func (s *StoreSuite) TestStoreMustFind() {
 	store := NewStoreFixtureStore(s.db)
 	s.Nil(store.Insert(NewStoreFixture()))
 	s.Nil(store.Insert(NewStoreFixture()))
@@ -45,12 +52,12 @@ func (s *CommonSuite) TestStoreMustFind() {
 
 }
 
-func (s *CommonSuite) TestStoreFailingOnNew() {
+func (s *StoreSuite) TestStoreFailingOnNew() {
 	doc := NewStoreWithConstructFixture("")
 	s.Nil(doc)
 }
 
-func (s *CommonSuite) TestStoreFindOne() {
+func (s *StoreSuite) TestStoreFindOne() {
 	store := NewStoreWithConstructFixtureStore(s.db)
 	s.Nil(store.Insert(NewStoreWithConstructFixture("bar")))
 
@@ -65,7 +72,7 @@ func (s *CommonSuite) TestStoreFindOne() {
 	s.Equal("bar", doc.Foo)
 }
 
-func (s *CommonSuite) TestStoreMustFindOne() {
+func (s *StoreSuite) TestStoreMustFindOne() {
 	store := NewStoreWithConstructFixtureStore(s.db)
 	s.Nil(store.Insert(NewStoreWithConstructFixture("foo")))
 	s.NotPanics(func() {
@@ -73,7 +80,7 @@ func (s *CommonSuite) TestStoreMustFindOne() {
 	})
 }
 
-func (s *CommonSuite) TestStoreInsertUpdate() {
+func (s *StoreSuite) TestStoreInsertUpdate() {
 	store := NewStoreWithConstructFixtureStore(s.db)
 
 	doc := NewStoreWithConstructFixture("foo")
@@ -92,7 +99,7 @@ func (s *CommonSuite) TestStoreInsertUpdate() {
 	})
 }
 
-func (s *CommonSuite) TestStoreSave() {
+func (s *StoreSuite) TestStoreSave() {
 	store := NewStoreWithConstructFixtureStore(s.db)
 
 	doc := NewStoreWithConstructFixture("foo")
@@ -113,7 +120,7 @@ func (s *CommonSuite) TestStoreSave() {
 	})
 }
 
-func (s *CommonSuite) TestStoreCustomNew() {
+func (s *StoreSuite) TestStoreCustomNew() {
 	store := NewStoreWithNewFixtureStore(s.db)
 
 	doc := store.New("foo", "bar")
@@ -129,7 +136,7 @@ func (s *CommonSuite) TestStoreCustomNew() {
 	})
 }
 
-func (s *CommonSuite) TestMultiKeySort() {
+func (s *StoreSuite) TestMultiKeySort() {
 	store := NewMultiKeySortFixtureStore(s.db)
 
 	var (


### PR DESCRIPTION
Each test suite should have its own schema to avoid interferences with other tests

Each test suite has its SetupSuite and TearDownSuite with a default behavior.
It can be passed an initialization queries to prepare the schema with the needed tables
