### PR TITLE
Use uuid v4 instead

### DIFF
--- a/model.go
+++ b/model.go
@@ -168,7 +168,7 @@ type ID uuid.UUID
 
 // NewID returns a new kallax ID.
 func NewID() ID {
-	return ID(uuid.NewV1())
+	return ID(uuid.NewV4())
 }
 
 // Scan implements the Scanner interface.


### PR DESCRIPTION
Since ULIDs can not be used, and no UUID is lexically sortable, we might as well use v4.