### PR TITLE
Implement customizable primary key types

### DIFF
--- a/batcher.go
+++ b/batcher.go
@@ -119,7 +119,7 @@ func (r *batchQueryRunner) processBatch(rows *sql.Rows) ([]Record, error) {
 
 	var ids = make([]interface{}, len(records))
 	for i, r := range records {
-		ids[i] = r.GetID()
+		ids[i] = r.GetID().Raw()
 	}
 
 	for _, rel := range r.oneToManyRels {
@@ -129,7 +129,7 @@ func (r *batchQueryRunner) processBatch(rows *sql.Rows) ([]Record, error) {
 		}
 
 		for _, r := range records {
-			err := r.SetRelationship(rel.Field, indexedResults[r.GetID()])
+			err := r.SetRelationship(rel.Field, indexedResults[r.GetID().Raw()])
 			if err != nil {
 				return nil, err
 			}
@@ -184,7 +184,8 @@ func (r *batchQueryRunner) getRecordRelationships(ids []interface{}, rel Relatio
 
 		rec.setPersisted()
 		rec.setWritable(true)
-		indexedResults[val] = append(indexedResults[val], rec)
+		id := val.(Identifier).Raw()
+		indexedResults[id] = append(indexedResults[id], rec)
 	}
 
 	if err := relRs.Close(); err != nil {

--- a/generator/processor_test.go
+++ b/generator/processor_test.go
@@ -27,13 +27,14 @@ func (s *ProcessorSuite) TestInlineStruct() {
 
   type Bar struct {
     kallax.Model
+	ID int64 ` + "`pk:\"autoincr\"`" + `
     Foo string
     R *Foo ` + "`kallax:\",inline\"`" + `
   }
   `
 
 	pkg := s.processFixture(fixtureSrc)
-	s.True(findModel(pkg, "Bar").Fields[2].Inline())
+	s.True(findModel(pkg, "Bar").Fields[3].Inline())
 }
 
 func (s *ProcessorSuite) TestTags() {
@@ -44,12 +45,13 @@ func (s *ProcessorSuite) TestTags() {
 
 	type Foo struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Int int "foo"
 	}
 	`
 
 	pkg := s.processFixture(fixtureSrc)
-	s.Equal(reflect.StructTag("foo"), findModel(pkg, "Foo").Fields[1].Tag)
+	s.Equal(reflect.StructTag("foo"), findModel(pkg, "Foo").Fields[2].Tag)
 }
 
 func (s *ProcessorSuite) TestRecursiveModel() {
@@ -60,6 +62,7 @@ func (s *ProcessorSuite) TestRecursiveModel() {
 
 	type Recur struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo string
 		R *Recur
 	}
@@ -80,6 +83,7 @@ func (s *ProcessorSuite) TestDeepRecursiveStruct() {
 
 	type Recur struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo string
 		Rec *Other
 	}
@@ -93,11 +97,11 @@ func (s *ProcessorSuite) TestDeepRecursiveStruct() {
 	m := findModel(pkg, "Recur")
 
 	s.Equal(
-		m.Fields[2].Fields[0].Fields[2].Node,
-		m.Fields[2].Node,
+		m.Fields[3].Fields[0].Fields[3].Node,
+		m.Fields[3].Node,
 		"indirect type recursivity not handled correctly.",
 	)
-	s.Len(pkg.Models[0].Fields[2].Fields[0].Fields[2].Fields, 0)
+	s.Len(pkg.Models[0].Fields[3].Fields[0].Fields[3].Fields, 0)
 }
 
 func (s *ProcessorSuite) TestIsEventPresent() {
@@ -108,6 +112,7 @@ func (s *ProcessorSuite) TestIsEventPresent() {
 
 	type Foo struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo string
 	}
 
@@ -152,6 +157,7 @@ func (s *ProcessorSuite) TestProcessField() {
 
 	type Related struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo string
 	}
 
@@ -170,6 +176,7 @@ func (s *ProcessorSuite) TestProcessField() {
 
 	type Foo struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Basic string
 		AliasBasic BasicAlias
 		BasicPtr *string
@@ -241,6 +248,7 @@ func (s *ProcessorSuite) TestCtor() {
 
 	type Foo struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo string
 	}
 
@@ -264,6 +272,7 @@ func (s *ProcessorSuite) TestSQLTypeIsInterface() {
 
 	type Foo struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo Bar
 	}
 
@@ -289,8 +298,9 @@ func (s *ProcessorSuite) TestIsSQLType() {
 
 	import 	"github.com/src-d/go-kallax"
 
-	type Foo struct {
+	type SQLTypeFixture struct {
 		kallax.Model
+		ID kallax.ULID ` + "`pk:\"\"`" + `
 		Foo string
 	}
 	`
@@ -298,9 +308,10 @@ func (s *ProcessorSuite) TestIsSQLType() {
 	p := s.processorFixture(fixtureSrc)
 	pkg, err := p.processPackage()
 	s.Nil(err)
-	m := findModel(pkg, "Foo")
+	m := findModel(pkg, "SQLTypeFixture")
 
-	s.True(isSQLType(p.Package, types.NewPointer(m.Fields[0].Fields[0].Node.Type())))
+	s.True(isSQLType(p.Package, types.NewPointer(m.ID.Node.Type())))
+	// model is index 1 because ID is always index 0
 	s.False(isSQLType(p.Package, types.NewPointer(m.Fields[1].Node.Type())))
 }
 
@@ -341,6 +352,7 @@ func (s *ProcessorSuite) TestIsModel() {
 
 	type Bar struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Bar string
 	}
 
@@ -350,6 +362,7 @@ func (s *ProcessorSuite) TestIsModel() {
 
 	type Foo struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo string
 		Ptr *Bar
 		NoPtr Bar
@@ -381,6 +394,7 @@ func (s *ProcessorSuite) TestIsEmbedded() {
 
 	type Bar struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Bar string
 	}
 
@@ -390,6 +404,7 @@ func (s *ProcessorSuite) TestIsEmbedded() {
 
 	type Foo struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		A Bar
 		B *Bar
 		Bar

--- a/generator/template_test.go
+++ b/generator/template_test.go
@@ -43,7 +43,7 @@ func (s *TemplateSuite) processSource(source string) {
 }
 
 const expectedAddresses = `case "id":
-return &r.Model.ID, nil
+return (*kallax.NumericID)(&r.ID), nil
 case "foo":
 return &r.Foo, nil
 case "bar":
@@ -57,7 +57,7 @@ return (*types.URL)(r.URL), nil
 case "url_no_ptr":
 return (*types.URL)(&r.UrlNoPtr), nil
 case "foo_id":
-return kallax.VirtualColumn("foo_id", r), nil
+return kallax.VirtualColumn("foo_id", r, new(kallax.NumericID)), nil
 `
 
 const baseTpl = `
@@ -68,6 +68,7 @@ const baseTpl = `
 
 	type Rel struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo string
 	}
 
@@ -77,6 +78,7 @@ const baseTpl = `
 
 	type Foo struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo string
 		Bar *string
 		Rel Rel
@@ -97,7 +99,7 @@ func (s *TemplateSuite) TestGenColumnAddresses() {
 }
 
 const expectedValues = `case "id":
-return r.Model.ID, nil
+return r.ID, nil
 case "foo":
 return r.Foo, nil
 case "bar":
@@ -127,6 +129,7 @@ func (s *TemplateSuite) TestGenColumnValues() {
 
 	type Rel struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo string
 	}
 
@@ -136,6 +139,7 @@ func (s *TemplateSuite) TestGenColumnValues() {
 
 	type Foo struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo string
 		Bar *string
 		Rel Rel
@@ -178,6 +182,7 @@ const jsonBaseTpl = `
 
 	type Rel struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo string
 	}
 
@@ -202,6 +207,7 @@ const jsonBaseTpl = `
 
 	type Foo struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Foo string
 		Bar *string
 		Arr []string
@@ -312,6 +318,7 @@ func (s *TemplateSuite) TestGenTypeName() {
 
 	type Foo struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Slice []string
 		Ptr *string
 		NoPtr string
@@ -346,6 +353,7 @@ func (s *TemplateSuite) TestIsPtrSlice() {
 
 	type Foo struct {
 		kallax.Model
+		ID int64 ` + "`pk:\"autoincr\"`" + `
 		Ptr *url.URL
 		Slice []url.URL
 		PtrSlice []*url.URL

--- a/generator/templates/model.tgo
+++ b/generator/templates/model.tgo
@@ -2,13 +2,19 @@
 
 // New{{.Name}} returns a new instance of {{.Name}}.
 func New{{.Name}}({{.CtorArgs}}) {{.CtorReturns}} {
-        {{.CtorRetVars}} = {{if .CtorFunc}}{{.CtorFunc.Name}}({{.CtorArgVars}}){{else}}&{{.Name}}{}{{end}}
-        if record != nil {
-                record.SetID(kallax.NewID())
-        }
-        return
+        return {{if .CtorFunc}}{{.CtorFunc.Name}}({{.CtorArgVars}}){{else}}new({{.Name}}){{end}}
 }
 
+// GetID returns the primary key of the model.
+func (r *{{.Name}}) GetID() kallax.Identifier {
+        {{- if .ID.IsPtr}}
+        return (*{{$.IdentifierType .ID}})(r.{{.ID.Name}})
+        {{- else }}
+        return (*{{$.IdentifierType .ID}})(&r.{{.ID.Name}})
+        {{- end }}
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *{{.Name}}) ColumnAddress(col string) (interface{}, error) {
         switch col {
                 {{$.GenColumnAddresses .}}
@@ -17,6 +23,7 @@ func (r *{{.Name}}) ColumnAddress(col string) (interface{}, error) {
         }
 }
 
+// Value returns the value of the given column.
 func (r *{{.Name}}) Value(col string) (interface{}, error) {
         switch col {
                 {{$.GenColumnValues .}}
@@ -25,6 +32,8 @@ func (r *{{.Name}}) Value(col string) (interface{}, error) {
         }
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *{{.Name}}) NewRelationshipRecord(field string) (kallax.Record, error) {
         {{if .Relationships -}}
         switch field {
@@ -38,6 +47,7 @@ func (r *{{.Name}}) NewRelationshipRecord(field string) (kallax.Record, error) {
         {{- end}}
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *{{.Name}}) SetRelationship(field string, rel interface{}) error {
         {{if .Relationships -}}
         switch field {
@@ -46,7 +56,7 @@ func (r *{{.Name}}) SetRelationship(field string, rel interface{}) error {
                 if !ok {
                         return fmt.Errorf("kallax: record of type %t can't be assigned to relationship {{.Name}}", rel)
                 }
-                {{if .IsPtr}}if !val.Model.ID.IsEmpty() {
+                {{if .IsPtr}}if !val.GetID().IsEmpty() {
                         r.{{.Name}} = val
                 }
                 {{else}}r.{{.Name}} = *val{{end}}
@@ -92,8 +102,8 @@ func (s *{{.StoreName}}) relationshipRecords(record *{{.Name}}) []kallax.RecordW
         var records []kallax.RecordWithSchema
         {{range .Relationships}}
         {{- if .IsInverse -}}
-        if {{if .IsPtr}}record.{{.Name}} != nil{{else}}!record.{{.Name}}.ID.IsEmpty(){{end}} {
-                record.AddVirtualColumn("{{.ForeignKey}}", record.{{.Name}}.ID)
+        if {{if .IsPtr}}record.{{.Name}} != nil{{else}}!record.{{.Name}}.GetID().IsEmpty(){{end}} {
+                record.AddVirtualColumn("{{.ForeignKey}}", record.{{.Name}}.GetID())
                 records = append(records, kallax.RecordWithSchema{
                         Schema.{{.TypeSchemaName}}.BaseSchema,
                         {{if not .IsPtr}}&{{end}}record.{{.Name}},
@@ -102,16 +112,16 @@ func (s *{{.StoreName}}) relationshipRecords(record *{{.Name}}) []kallax.RecordW
         {{else if .IsOneToManyRelationship}}
         for _, rec := range record.{{.Name}} {
                 rec.ClearVirtualColumns()
-                rec.AddVirtualColumn("{{.ForeignKey}}", record.ID)
+                rec.AddVirtualColumn("{{.ForeignKey}}", record.GetID())
                 records = append(records, kallax.RecordWithSchema{
                         Schema.{{.TypeSchemaName}}.BaseSchema,
                         {{if not ($.IsPtrSlice .)}}&{{end}}rec,
                 })
         }
         {{else}}
-        if {{if .IsPtr}}record.{{.Name}} != nil{{else}}!record.{{.Name}}.ID.IsEmpty(){{end}} {
+        if {{if .IsPtr}}record.{{.Name}} != nil{{else}}!record.{{.Name}}.GetID().IsEmpty(){{end}} {
                 record.{{.Name}}.ClearVirtualColumns()
-                record.{{.Name}}.AddVirtualColumn("{{.ForeignKey}}", record.ID)
+                record.{{.Name}}.AddVirtualColumn("{{.ForeignKey}}", record.GetID())
                 records = append(records, kallax.RecordWithSchema{
                         Schema.{{.TypeSchemaName}}.BaseSchema,
                         {{if not .IsPtr}}&{{end}}record.{{.Name}},
@@ -483,7 +493,7 @@ func (s *{{.Model.StoreName}}) Remove{{.Name}}(record *{{.Model.Name}}, deleted 
         for _, r := range record.{{.Name}} {
                 var found bool
                 for _, d := range deleted {
-                        if d.ID == r.ID {
+                        if d.GetID().Equals(r.GetID()) {
                                 found = true
                                 break
                         }

--- a/generator/templates/schema.tgo
+++ b/generator/templates/schema.tgo
@@ -18,7 +18,7 @@ var Schema = &schema{
         BaseSchema: kallax.NewBaseSchema(
                 "{{.Table}}",
                 "{{.Alias}}",
-                kallax.NewSchemaField("id"),
+                kallax.NewSchemaField("{{.ID.ColumnName}}"),
                 kallax.ForeignKeys{
                 {{range .Relationships}}"{{.Name}}": kallax.NewForeignKey("{{.ForeignKey}}", {{if .IsInverse}}true{{else}}false{{end}}),
                 {{end}}
@@ -26,6 +26,7 @@ var Schema = &schema{
                 func() kallax.Record {
                         return new({{.Name}})
                 },
+                {{if .ID.IsAutoIncrement}}true{{else}}false{{end}},
                 {{$.GenModelColumns .}}
         ),
         {{$.GenSchemaInit .}}

--- a/model_test.go
+++ b/model_test.go
@@ -6,26 +6,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIDIsEmpty(t *testing.T) {
+func TestUULIDIsEmpty(t *testing.T) {
 	r := require.New(t)
-	var id ID
+	var id ULID
 	r.True(id.IsEmpty())
 
-	id = NewID()
+	id = NewULID()
 	r.False(id.IsEmpty())
 }
 
-func TestID_Value(t *testing.T) {
-	id := NewID()
+func TestULID_Value(t *testing.T) {
+	id := NewULID()
 	v, _ := id.Value()
 	require.Equal(t, id.String(), v)
 }
 
-func TestID_ThreeNewIDsAreDifferent(t *testing.T) {
+func TestUULID_ThreeNewIDsAreDifferent(t *testing.T) {
 	r := require.New(t)
-	id1 := NewID()
-	id2 := NewID()
-	id3 := NewID()
+	id1 := NewULID()
+	id2 := NewULID()
+	id3 := NewULID()
 
 	r.NotEqual(id1, id2)
 	r.NotEqual(id1, id3)
@@ -35,14 +35,14 @@ func TestID_ThreeNewIDsAreDifferent(t *testing.T) {
 	r.False(id1 == id2)
 }
 
-func TestID_ScanValue(t *testing.T) {
+func TestULID_ScanValue(t *testing.T) {
 	r := require.New(t)
 
-	expected := NewID()
+	expected := NewULID()
 	v, err := expected.Value()
 	r.NoError(err)
 
-	var id ID
+	var id ULID
 	r.NoError(id.Scan(v))
 
 	r.Equal(expected, id)
@@ -56,14 +56,14 @@ func TestVirtualColumn(t *testing.T) {
 	r.Equal(nil, record.VirtualColumn("foo"))
 
 	record.virtualColumns = nil
-	s := VirtualColumn("foo", record)
+	s := VirtualColumn("foo", record, new(ULID))
 
-	id := NewID()
+	id := NewULID()
 	v, err := id.Value()
 	r.NoError(err)
 	r.NoError(s.Scan(v))
 	r.Len(record.virtualColumns, 1)
-	r.Equal(id, record.VirtualColumn("foo"))
+	r.Equal(&id, record.VirtualColumn("foo"))
 
 	r.Error(s.Scan(nil))
 }

--- a/operators_test.go
+++ b/operators_test.go
@@ -33,7 +33,7 @@ func (s *OpsSuite) remove(table string) {
 
 func (s *OpsSuite) TestOperators() {
 	s.create(`CREATE TABLE model (
-		id uuid PRIMARY KEY,
+		id serial PRIMARY KEY,
 		name varchar(255) not null,
 		email varchar(255) not null,
 		age int not null
@@ -108,7 +108,7 @@ func (s *OpsSuite) TestArrayOperators() {
 		{"ArrayOverlap fail", ArrayOverlap(f, 6, 7, 8, 9), false},
 	}
 
-	_, err := s.db.Exec("INSERT INTO slices (id,elems) VALUES ($1, $2)", NewID(), types.Slice([]int64{1, 2, 3}))
+	_, err := s.db.Exec("INSERT INTO slices (id,elems) VALUES ($1, $2)", NewULID(), types.Slice([]int64{1, 2, 3}))
 	s.NoError(err)
 
 	for _, c := range cases {
@@ -174,7 +174,7 @@ func (s *OpsSuite) TestJSONOperators() {
 	}
 
 	for _, r := range records {
-		_, err := s.db.Exec("INSERT INTO jsons (id,elem) VALUES ($1, $2)", NewID(), types.JSON(r))
+		_, err := s.db.Exec("INSERT INTO jsons (id,elem) VALUES ($1, $2)", NewULID(), types.JSON(r))
 		s.NoError(err)
 	}
 

--- a/schema.go
+++ b/schema.go
@@ -25,6 +25,7 @@ type Schema interface {
 	WithAlias(string) Schema
 	// New creates a new record with the given schema.
 	New() Record
+	isPrimaryKeyAutoIncrementable() bool
 }
 
 // BaseSchema is the basic implementation of Schema.
@@ -35,6 +36,7 @@ type BaseSchema struct {
 	id          SchemaField
 	columns     []SchemaField
 	constructor RecordConstructor
+	autoIncr    bool
 }
 
 // RecordConstructor is a function that creates a record.
@@ -42,7 +44,7 @@ type RecordConstructor func() Record
 
 // NewBaseSchema creates a new schema with the given table, alias, identifier
 // and columns.
-func NewBaseSchema(table, alias string, id SchemaField, fks ForeignKeys, ctor RecordConstructor, columns ...SchemaField) *BaseSchema {
+func NewBaseSchema(table, alias string, id SchemaField, fks ForeignKeys, ctor RecordConstructor, autoIncr bool, columns ...SchemaField) *BaseSchema {
 	return &BaseSchema{
 		alias:       alias,
 		table:       table,
@@ -50,6 +52,7 @@ func NewBaseSchema(table, alias string, id SchemaField, fks ForeignKeys, ctor Re
 		id:          id,
 		columns:     columns,
 		constructor: ctor,
+		autoIncr:    autoIncr,
 	}
 }
 
@@ -67,6 +70,7 @@ func (s *BaseSchema) WithAlias(field string) Schema {
 func (s *BaseSchema) New() Record {
 	return s.constructor()
 }
+func (s *BaseSchema) isPrimaryKeyAutoIncrementable() bool { return s.autoIncr }
 
 type aliasSchema struct {
 	*BaseSchema

--- a/schema_test.go
+++ b/schema_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var emptySchema = NewBaseSchema("", "", nil, nil, nil)
+var emptySchema = NewBaseSchema("", "", nil, nil, nil, false)
 
 func TestBaseSchemaFieldQualifiedName(t *testing.T) {
 	var cases = []struct {

--- a/store_test.go
+++ b/store_test.go
@@ -57,7 +57,7 @@ func (s *StoreSuite) TestInsert_NotNew() {
 func (s *StoreSuite) TestInsert_IDEmpty() {
 	var m = new(model)
 	s.Nil(s.store.Insert(ModelSchema, m))
-	s.False(m.ID.IsEmpty())
+	s.False(m.GetID().IsEmpty())
 }
 
 func (s *StoreSuite) TestUpdate() {
@@ -65,12 +65,12 @@ func (s *StoreSuite) TestUpdate() {
 	s.Nil(s.store.Insert(ModelSchema, m))
 
 	var newModel = newModel("a", "a@a.a", 1)
-	newModel.SetID(m.ID)
+	newModel.ID = m.ID
 	_, err := s.store.Update(ModelSchema, newModel)
 	s.Equal(ErrNewDocument, err)
 
 	newModel.setPersisted()
-	newModel.SetID(ID{})
+	newModel.ID = 0
 	_, err = s.store.Update(ModelSchema, newModel)
 	s.Equal(ErrEmptyID, err)
 
@@ -99,7 +99,7 @@ func (s *StoreSuite) TestUpdate_NotUpdated() {
 	var m = newModel("a", "a@a.a", 1)
 	s.Nil(s.store.Insert(ModelSchema, m))
 
-	m.ID = NewID()
+	m.ID = 567
 	_, err := s.store.Update(ModelSchema, m)
 	s.Equal(ErrNoRowUpdate, err)
 }
@@ -341,6 +341,7 @@ func (s *StoreSuite) TestReload_Fail() {
 
 func (s *StoreSuite) TestReload_NotFound() {
 	var m = newModel("Joe", "", 1)
+	m.ID = 1
 	m.setPersisted()
 
 	s.Equal(ErrNotFound, s.store.Reload(ModelSchema, m))
@@ -350,11 +351,11 @@ func (s *StoreSuite) TestFind_1to1() {
 	m := newModel("Foo", "bar", 1)
 	s.Nil(s.store.Insert(ModelSchema, m))
 
-	rel := newRel(m.ID, "foo")
+	rel := newRel(m.GetID(), "foo")
 	s.Nil(s.store.Insert(RelSchema, rel))
 
 	// just to see it does not randomly takes the most recent one
-	s.Nil(s.store.Insert(RelSchema, newRel(NewID(), "foo")))
+	s.Nil(s.store.Insert(RelSchema, newRel(new(NumericID), "foo")))
 
 	q := NewBaseQuery(ModelSchema)
 	q.AddRelation(RelSchema, "rel", OneToOne, nil)
@@ -371,7 +372,7 @@ func (s *StoreSuite) TestFind_1to1() {
 	s.Equal("bar", model.Email)
 	s.Equal(1, model.Age)
 	s.NotNil(model.Rel)
-	s.Equal(model.ID, model.Rel.ModelID)
+	s.Equal(model.GetID(), model.Rel.VirtualColumn("model_id"))
 	s.Equal("foo", model.Rel.Foo)
 }
 
@@ -381,11 +382,11 @@ func (s *StoreSuite) rel1ToNFixtures() {
 
 	rels := []string{"foo", "bar", "baz"}
 	for _, v := range rels {
-		rel := newRel(m.ID, v)
+		rel := newRel(m.GetID(), v)
 		s.Nil(s.store.Insert(RelSchema, rel))
 	}
 
-	s.Nil(s.store.Insert(RelSchema, newRel(NewID(), "qux")))
+	s.Nil(s.store.Insert(RelSchema, newRel(new(NumericID), "qux")))
 }
 
 func (s *StoreSuite) TestFind_1toN() {
@@ -406,7 +407,7 @@ func (s *StoreSuite) TestFind_1toN() {
 	s.Equal("bar", model.Email)
 	s.Equal(1, model.Age)
 	s.Nil(model.Rel)
-	s.Len(model.Rels, 3)
+	s.Require().Len(model.Rels, 3)
 	s.Equal("foo", model.Rels[0].Foo)
 	s.Equal("bar", model.Rels[1].Foo)
 	s.Equal("baz", model.Rels[2].Foo)
@@ -430,7 +431,7 @@ func (s *StoreSuite) TestFind_1toN_Filter() {
 	s.Equal("bar", model.Email)
 	s.Equal(1, model.Age)
 	s.Nil(model.Rel)
-	s.Len(model.Rels, 1)
+	s.Require().Len(model.Rels, 1)
 	s.Equal("bar", model.Rels[0].Foo)
 }
 
@@ -466,7 +467,7 @@ func (s *StoreSuite) TestFind_1toNMultiple() {
 		s.Nil(s.store.Insert(ModelSchema, m))
 
 		for _, v := range rels {
-			s.Nil(s.store.Insert(RelSchema, newRel(m.ID, fmt.Sprintf("%s%d", v, i))))
+			s.Nil(s.store.Insert(RelSchema, newRel(m.GetID(), fmt.Sprintf("%s%d", v, i))))
 		}
 	}
 
@@ -485,10 +486,10 @@ func (s *StoreSuite) TestFind_1toNMultiple() {
 		s.True(ok, "row #%d", i)
 
 		s.Equal(fmt.Sprint(i), model.Name, "row #%d", i)
-		s.Len(model.Rels, 3, "row #%d", i)
+		s.Require().Len(model.Rels, 3, "row #%d", i)
 
 		for j, v := range rels {
-			s.Equal(model.ID, model.Rels[j].ModelID, "row #%d", i)
+			s.Equal(model.GetID(), model.Rels[j].VirtualColumn("model_id"), "row #%d", i)
 			s.Equal(fmt.Sprintf("%s%d", v, i), model.Rels[j].Foo, "row #%d", i)
 		}
 		i++
@@ -498,12 +499,12 @@ func (s *StoreSuite) TestFind_1toNMultiple() {
 
 func (s *StoreSuite) assertModel(m *model) {
 	var result model
-	err := s.db.QueryRow("SELECT id, name, email, age FROM model WHERE id = $1", m.ID).
-		Scan(&result.ID, &result.Name, &result.Email, &result.Age)
+	err := s.db.QueryRow("SELECT id, name, email, age FROM model WHERE id = $1", m.GetID()).
+		Scan(result.GetID(), &result.Name, &result.Email, &result.Age)
 	s.Nil(err)
 
 	if err == nil {
-		s.Equal(m.ID, result.ID)
+		s.Equal(m.GetID(), result.GetID())
 		s.Equal(m.Name, result.Name)
 		s.Equal(m.Email, result.Email)
 		s.Equal(m.Age, result.Age)
@@ -517,8 +518,8 @@ func (s *StoreSuite) assertCount(n int64) {
 }
 
 func (s *StoreSuite) assertNotExists(m *model) {
-	var id ID
-	err := s.db.QueryRow("SELECT id FROM model WHERE id = $1", m.ID).Scan(&id)
+	var id int64
+	err := s.db.QueryRow("SELECT id FROM model WHERE id = $1", m.GetID()).Scan(&id)
 	s.Equal(sql.ErrNoRows, err, "record should not exist")
 }
 

--- a/tests/events.go
+++ b/tests/events.go
@@ -4,6 +4,7 @@ import "github.com/src-d/go-kallax"
 
 type EventsFixture struct {
 	kallax.Model   `table:"event"`
+	ID             kallax.ULID `pk:""`
 	Checks         map[string]bool
 	MustFailBefore error
 	MustFailAfter  error
@@ -11,6 +12,7 @@ type EventsFixture struct {
 
 func newEventsFixture() *EventsFixture {
 	return &EventsFixture{
+		ID:     kallax.NewULID(),
 		Checks: make(map[string]bool, 0),
 	}
 }
@@ -53,6 +55,7 @@ func (s *EventsFixture) AfterUpdate() error {
 
 type EventsSaveFixture struct {
 	kallax.Model   `table:"event"`
+	ID             kallax.ULID `pk:""`
 	Checks         map[string]bool
 	MustFailBefore error
 	MustFailAfter  error
@@ -60,6 +63,7 @@ type EventsSaveFixture struct {
 
 func newEventsSaveFixture() *EventsSaveFixture {
 	return &EventsSaveFixture{
+		ID:     kallax.NewULID(),
 		Checks: make(map[string]bool, 0),
 	}
 }
@@ -84,6 +88,7 @@ func (s *EventsSaveFixture) AfterSave() error {
 
 type EventsAllFixture struct {
 	kallax.Model   `table:"event"`
+	ID             kallax.ULID `pk:""`
 	Checks         map[string]bool
 	MustFailBefore error
 	MustFailAfter  error
@@ -91,6 +96,7 @@ type EventsAllFixture struct {
 
 func newEventsAllFixture() *EventsAllFixture {
 	return &EventsAllFixture{
+		ID:     kallax.NewULID(),
 		Checks: make(map[string]bool, 0),
 	}
 }

--- a/tests/events_test.go
+++ b/tests/events_test.go
@@ -29,14 +29,12 @@ type eventsCheck map[string]bool
 func (s *EventsSuite) assertEventsPassed(expected eventsCheck, received eventsCheck) {
 	for expectedEvent, expectedSign := range expected {
 		receivedSign, ok := received[expectedEvent]
-		if s.True(ok, fmt.Sprintf(`Event '%s' was not received
-		// TODO: https://github.com/src-d/go-kallax/issues/56
-		`, expectedEvent)) {
+		if s.True(ok, fmt.Sprintf(`Event '%s' was not received`, expectedEvent)) {
 			s.Equal(expectedSign, receivedSign, expectedEvent)
 		}
 	}
 
-	s.Equal(len(expected), len(received), "// TODO: https://github.com/src-d/go-kallax/issues/56")
+	s.Equal(len(expected), len(received), "expected same number of events")
 }
 
 func (s *EventsSuite) TestEventsInsert() {
@@ -77,8 +75,8 @@ func (s *EventsSuite) TestEventsUpdateError() {
 
 	doc.MustFailAfter = errors.New("kallax: after")
 	updatedRows, err := store.Update(doc)
-	s.Equal(int64(0), updatedRows, "// TODO: https://github.com/src-d/go-kallax/issues/56")
-	s.Equal(doc.MustFailAfter, err, "// TODO: https://github.com/src-d/go-kallax/issues/56")
+	s.Equal(int64(0), updatedRows)
+	s.Equal(doc.MustFailAfter, err)
 
 	doc.MustFailBefore = errors.New("kallax: before")
 	updatedRows, err = store.Update(doc)

--- a/tests/json.go
+++ b/tests/json.go
@@ -4,6 +4,7 @@ import kallax "github.com/src-d/go-kallax"
 
 type JSONModel struct {
 	kallax.Model `table:"jsons"`
+	ID           kallax.ULID `pk:""`
 	Foo          string
 	Bar          *Bar
 	BazSlice     []Baz
@@ -26,5 +27,5 @@ type Qux struct {
 }
 
 func newJSONModel() *JSONModel {
-	return &JSONModel{Baz: make(map[string]interface{})}
+	return &JSONModel{ID: kallax.NewULID(), Baz: make(map[string]interface{})}
 }

--- a/tests/kallax.go
+++ b/tests/kallax.go
@@ -17,19 +17,21 @@ var _ fmt.Formatter
 
 // NewCar returns a new instance of Car.
 func NewCar(model string, owner *Person) (record *Car) {
-	record = newCar(model, owner)
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newCar(model, owner)
 }
 
+// GetID returns the primary key of the model.
+func (r *Car) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *Car) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "owner_id":
-		return kallax.VirtualColumn("owner_id", r), nil
+		return kallax.VirtualColumn("owner_id", r, new(kallax.NumericID)), nil
 	case "model_name":
 		return &r.ModelName, nil
 
@@ -38,10 +40,11 @@ func (r *Car) ColumnAddress(col string) (interface{}, error) {
 	}
 }
 
+// Value returns the value of the given column.
 func (r *Car) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "owner_id":
 		return r.Model.VirtualColumn(col), nil
 	case "model_name":
@@ -52,6 +55,8 @@ func (r *Car) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *Car) NewRelationshipRecord(field string) (kallax.Record, error) {
 	switch field {
 	case "Owner":
@@ -61,6 +66,7 @@ func (r *Car) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model Car has no relationship %s", field)
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *Car) SetRelationship(field string, rel interface{}) error {
 	switch field {
 	case "Owner":
@@ -68,7 +74,7 @@ func (r *Car) SetRelationship(field string, rel interface{}) error {
 		if !ok {
 			return fmt.Errorf("kallax: record of type %t can't be assigned to relationship Owner", rel)
 		}
-		if !val.Model.ID.IsEmpty() {
+		if !val.GetID().IsEmpty() {
 			r.Owner = val
 		}
 
@@ -94,7 +100,7 @@ func (s *CarStore) relationshipRecords(record *Car) []kallax.RecordWithSchema {
 	record.ClearVirtualColumns()
 	var records []kallax.RecordWithSchema
 	if record.Owner != nil {
-		record.AddVirtualColumn("owner_id", record.Owner.ID)
+		record.AddVirtualColumn("owner_id", record.Owner.GetID())
 		records = append(records, kallax.RecordWithSchema{
 			Schema.Person.BaseSchema,
 			record.Owner,
@@ -524,17 +530,19 @@ func (rs *CarResultSet) Close() error {
 
 // NewEventsAllFixture returns a new instance of EventsAllFixture.
 func NewEventsAllFixture() (record *EventsAllFixture) {
-	record = newEventsAllFixture()
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newEventsAllFixture()
 }
 
+// GetID returns the primary key of the model.
+func (r *EventsAllFixture) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *EventsAllFixture) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "checks":
 		return types.JSON(&r.Checks), nil
 	case "must_fail_before":
@@ -547,10 +555,11 @@ func (r *EventsAllFixture) ColumnAddress(col string) (interface{}, error) {
 	}
 }
 
+// Value returns the value of the given column.
 func (r *EventsAllFixture) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "checks":
 		return types.JSON(r.Checks), nil
 	case "must_fail_before":
@@ -563,10 +572,13 @@ func (r *EventsAllFixture) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *EventsAllFixture) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model EventsAllFixture has no relationships")
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *EventsAllFixture) SetRelationship(field string, rel interface{}) error {
 	return fmt.Errorf("kallax: model EventsAllFixture has no relationships")
 }
@@ -937,17 +949,19 @@ func (rs *EventsAllFixtureResultSet) Close() error {
 
 // NewEventsFixture returns a new instance of EventsFixture.
 func NewEventsFixture() (record *EventsFixture) {
-	record = newEventsFixture()
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newEventsFixture()
 }
 
+// GetID returns the primary key of the model.
+func (r *EventsFixture) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *EventsFixture) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "checks":
 		return types.JSON(&r.Checks), nil
 	case "must_fail_before":
@@ -960,10 +974,11 @@ func (r *EventsFixture) ColumnAddress(col string) (interface{}, error) {
 	}
 }
 
+// Value returns the value of the given column.
 func (r *EventsFixture) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "checks":
 		return types.JSON(r.Checks), nil
 	case "must_fail_before":
@@ -976,10 +991,13 @@ func (r *EventsFixture) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *EventsFixture) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model EventsFixture has no relationships")
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *EventsFixture) SetRelationship(field string, rel interface{}) error {
 	return fmt.Errorf("kallax: model EventsFixture has no relationships")
 }
@@ -1334,17 +1352,19 @@ func (rs *EventsFixtureResultSet) Close() error {
 
 // NewEventsSaveFixture returns a new instance of EventsSaveFixture.
 func NewEventsSaveFixture() (record *EventsSaveFixture) {
-	record = newEventsSaveFixture()
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newEventsSaveFixture()
 }
 
+// GetID returns the primary key of the model.
+func (r *EventsSaveFixture) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *EventsSaveFixture) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "checks":
 		return types.JSON(&r.Checks), nil
 	case "must_fail_before":
@@ -1357,10 +1377,11 @@ func (r *EventsSaveFixture) ColumnAddress(col string) (interface{}, error) {
 	}
 }
 
+// Value returns the value of the given column.
 func (r *EventsSaveFixture) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "checks":
 		return types.JSON(r.Checks), nil
 	case "must_fail_before":
@@ -1373,10 +1394,13 @@ func (r *EventsSaveFixture) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *EventsSaveFixture) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model EventsSaveFixture has no relationships")
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *EventsSaveFixture) SetRelationship(field string, rel interface{}) error {
 	return fmt.Errorf("kallax: model EventsSaveFixture has no relationships")
 }
@@ -1731,17 +1755,19 @@ func (rs *EventsSaveFixtureResultSet) Close() error {
 
 // NewJSONModel returns a new instance of JSONModel.
 func NewJSONModel() (record *JSONModel) {
-	record = newJSONModel()
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newJSONModel()
 }
 
+// GetID returns the primary key of the model.
+func (r *JSONModel) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *JSONModel) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "foo":
 		return &r.Foo, nil
 	case "bar":
@@ -1759,10 +1785,11 @@ func (r *JSONModel) ColumnAddress(col string) (interface{}, error) {
 	}
 }
 
+// Value returns the value of the given column.
 func (r *JSONModel) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "foo":
 		return r.Foo, nil
 	case "bar":
@@ -1777,10 +1804,13 @@ func (r *JSONModel) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *JSONModel) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model JSONModel has no relationships")
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *JSONModel) SetRelationship(field string, rel interface{}) error {
 	return fmt.Errorf("kallax: model JSONModel has no relationships")
 }
@@ -2101,17 +2131,19 @@ func (rs *JSONModelResultSet) Close() error {
 
 // NewMultiKeySortFixture returns a new instance of MultiKeySortFixture.
 func NewMultiKeySortFixture() (record *MultiKeySortFixture) {
-	record = &MultiKeySortFixture{}
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newMultiKeySortFixture()
 }
 
+// GetID returns the primary key of the model.
+func (r *MultiKeySortFixture) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *MultiKeySortFixture) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "name":
 		return &r.Name, nil
 	case "start":
@@ -2124,10 +2156,11 @@ func (r *MultiKeySortFixture) ColumnAddress(col string) (interface{}, error) {
 	}
 }
 
+// Value returns the value of the given column.
 func (r *MultiKeySortFixture) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "name":
 		return r.Name, nil
 	case "start":
@@ -2140,10 +2173,13 @@ func (r *MultiKeySortFixture) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *MultiKeySortFixture) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model MultiKeySortFixture has no relationships")
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *MultiKeySortFixture) SetRelationship(field string, rel interface{}) error {
 	return fmt.Errorf("kallax: model MultiKeySortFixture has no relationships")
 }
@@ -2464,17 +2500,19 @@ func (rs *MultiKeySortFixtureResultSet) Close() error {
 
 // NewPerson returns a new instance of Person.
 func NewPerson(name string) (record *Person) {
-	record = newPerson(name)
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newPerson(name)
 }
 
+// GetID returns the primary key of the model.
+func (r *Person) GetID() kallax.Identifier {
+	return (*kallax.NumericID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *Person) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.NumericID)(&r.ID), nil
 	case "name":
 		return &r.Name, nil
 
@@ -2483,10 +2521,11 @@ func (r *Person) ColumnAddress(col string) (interface{}, error) {
 	}
 }
 
+// Value returns the value of the given column.
 func (r *Person) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "name":
 		return r.Name, nil
 
@@ -2495,6 +2534,8 @@ func (r *Person) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *Person) NewRelationshipRecord(field string) (kallax.Record, error) {
 	switch field {
 	case "Pets":
@@ -2506,6 +2547,7 @@ func (r *Person) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model Person has no relationship %s", field)
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *Person) SetRelationship(field string, rel interface{}) error {
 	switch field {
 	case "Pets":
@@ -2528,7 +2570,7 @@ func (r *Person) SetRelationship(field string, rel interface{}) error {
 		if !ok {
 			return fmt.Errorf("kallax: record of type %t can't be assigned to relationship Car", rel)
 		}
-		if !val.Model.ID.IsEmpty() {
+		if !val.GetID().IsEmpty() {
 			r.Car = val
 		}
 
@@ -2556,7 +2598,7 @@ func (s *PersonStore) relationshipRecords(record *Person) []kallax.RecordWithSch
 
 	for _, rec := range record.Pets {
 		rec.ClearVirtualColumns()
-		rec.AddVirtualColumn("owner_id", record.ID)
+		rec.AddVirtualColumn("owner_id", record.GetID())
 		records = append(records, kallax.RecordWithSchema{
 			Schema.Pet.BaseSchema,
 			rec,
@@ -2565,7 +2607,7 @@ func (s *PersonStore) relationshipRecords(record *Person) []kallax.RecordWithSch
 
 	if record.Car != nil {
 		record.Car.ClearVirtualColumns()
-		record.Car.AddVirtualColumn("owner_id", record.ID)
+		record.Car.AddVirtualColumn("owner_id", record.GetID())
 		records = append(records, kallax.RecordWithSchema{
 			Schema.Car.BaseSchema,
 			record.Car,
@@ -2888,7 +2930,7 @@ func (s *PersonStore) RemovePets(record *Person, deleted ...*Pet) error {
 	for _, r := range record.Pets {
 		var found bool
 		for _, d := range deleted {
-			if d.ID == r.ID {
+			if d.GetID().Equals(r.GetID()) {
 				found = true
 				break
 			}
@@ -3120,33 +3162,36 @@ func (rs *PersonResultSet) Close() error {
 
 // NewPet returns a new instance of Pet.
 func NewPet(name string, kind string, owner *Person) (record *Pet) {
-	record = newPet(name, kind, owner)
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newPet(name, kind, owner)
 }
 
+// GetID returns the primary key of the model.
+func (r *Pet) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *Pet) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "name":
 		return &r.Name, nil
 	case "kind":
 		return &r.Kind, nil
 	case "owner_id":
-		return kallax.VirtualColumn("owner_id", r), nil
+		return kallax.VirtualColumn("owner_id", r, new(kallax.NumericID)), nil
 
 	default:
 		return nil, fmt.Errorf("kallax: invalid column in Pet: %s", col)
 	}
 }
 
+// Value returns the value of the given column.
 func (r *Pet) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "name":
 		return r.Name, nil
 	case "kind":
@@ -3159,6 +3204,8 @@ func (r *Pet) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *Pet) NewRelationshipRecord(field string) (kallax.Record, error) {
 	switch field {
 	case "Owner":
@@ -3168,6 +3215,7 @@ func (r *Pet) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model Pet has no relationship %s", field)
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *Pet) SetRelationship(field string, rel interface{}) error {
 	switch field {
 	case "Owner":
@@ -3175,7 +3223,7 @@ func (r *Pet) SetRelationship(field string, rel interface{}) error {
 		if !ok {
 			return fmt.Errorf("kallax: record of type %t can't be assigned to relationship Owner", rel)
 		}
-		if !val.Model.ID.IsEmpty() {
+		if !val.GetID().IsEmpty() {
 			r.Owner = val
 		}
 
@@ -3201,7 +3249,7 @@ func (s *PetStore) relationshipRecords(record *Pet) []kallax.RecordWithSchema {
 	record.ClearVirtualColumns()
 	var records []kallax.RecordWithSchema
 	if record.Owner != nil {
-		record.AddVirtualColumn("owner_id", record.Owner.ID)
+		record.AddVirtualColumn("owner_id", record.Owner.GetID())
 		records = append(records, kallax.RecordWithSchema{
 			Schema.Person.BaseSchema,
 			record.Owner,
@@ -3631,17 +3679,19 @@ func (rs *PetResultSet) Close() error {
 
 // NewQueryFixture returns a new instance of QueryFixture.
 func NewQueryFixture(f string) (record *QueryFixture) {
-	record = newQueryFixture(f)
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newQueryFixture(f)
 }
 
+// GetID returns the primary key of the model.
+func (r *QueryFixture) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *QueryFixture) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "foo":
 		return &r.Foo, nil
 
@@ -3650,10 +3700,11 @@ func (r *QueryFixture) ColumnAddress(col string) (interface{}, error) {
 	}
 }
 
+// Value returns the value of the given column.
 func (r *QueryFixture) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "foo":
 		return r.Foo, nil
 
@@ -3662,10 +3713,13 @@ func (r *QueryFixture) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *QueryFixture) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model QueryFixture has no relationships")
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *QueryFixture) SetRelationship(field string, rel interface{}) error {
 	return fmt.Errorf("kallax: model QueryFixture has no relationships")
 }
@@ -3986,17 +4040,19 @@ func (rs *QueryFixtureResultSet) Close() error {
 
 // NewResultSetFixture returns a new instance of ResultSetFixture.
 func NewResultSetFixture(f string) (record *ResultSetFixture) {
-	record = newResultSetFixture(f)
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newResultSetFixture(f)
 }
 
+// GetID returns the primary key of the model.
+func (r *ResultSetFixture) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *ResultSetFixture) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "foo":
 		return &r.Foo, nil
 
@@ -4005,10 +4061,11 @@ func (r *ResultSetFixture) ColumnAddress(col string) (interface{}, error) {
 	}
 }
 
+// Value returns the value of the given column.
 func (r *ResultSetFixture) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "foo":
 		return r.Foo, nil
 
@@ -4017,10 +4074,13 @@ func (r *ResultSetFixture) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *ResultSetFixture) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model ResultSetFixture has no relationships")
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *ResultSetFixture) SetRelationship(field string, rel interface{}) error {
 	return fmt.Errorf("kallax: model ResultSetFixture has no relationships")
 }
@@ -4341,17 +4401,19 @@ func (rs *ResultSetFixtureResultSet) Close() error {
 
 // NewSchemaFixture returns a new instance of SchemaFixture.
 func NewSchemaFixture() (record *SchemaFixture) {
-	record = &SchemaFixture{}
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newSchemaFixture()
 }
 
+// GetID returns the primary key of the model.
+func (r *SchemaFixture) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *SchemaFixture) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "string":
 		return &r.String, nil
 	case "int":
@@ -4370,10 +4432,11 @@ func (r *SchemaFixture) ColumnAddress(col string) (interface{}, error) {
 	}
 }
 
+// Value returns the value of the given column.
 func (r *SchemaFixture) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "string":
 		return r.String, nil
 	case "int":
@@ -4392,6 +4455,8 @@ func (r *SchemaFixture) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *SchemaFixture) NewRelationshipRecord(field string) (kallax.Record, error) {
 	switch field {
 	case "Nested":
@@ -4401,6 +4466,7 @@ func (r *SchemaFixture) NewRelationshipRecord(field string) (kallax.Record, erro
 	return nil, fmt.Errorf("kallax: model SchemaFixture has no relationship %s", field)
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *SchemaFixture) SetRelationship(field string, rel interface{}) error {
 	switch field {
 	case "Nested":
@@ -4408,7 +4474,7 @@ func (r *SchemaFixture) SetRelationship(field string, rel interface{}) error {
 		if !ok {
 			return fmt.Errorf("kallax: record of type %t can't be assigned to relationship Nested", rel)
 		}
-		if !val.Model.ID.IsEmpty() {
+		if !val.GetID().IsEmpty() {
 			r.Nested = val
 		}
 
@@ -4436,7 +4502,7 @@ func (s *SchemaFixtureStore) relationshipRecords(record *SchemaFixture) []kallax
 
 	if record.Nested != nil {
 		record.Nested.ClearVirtualColumns()
-		record.Nested.AddVirtualColumn("schema_fixture_id", record.ID)
+		record.Nested.AddVirtualColumn("schema_fixture_id", record.GetID())
 		records = append(records, kallax.RecordWithSchema{
 			Schema.SchemaFixture.BaseSchema,
 			record.Nested,
@@ -4844,17 +4910,19 @@ func (rs *SchemaFixtureResultSet) Close() error {
 
 // NewStoreFixture returns a new instance of StoreFixture.
 func NewStoreFixture() (record *StoreFixture) {
-	record = &StoreFixture{}
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newStoreFixture()
 }
 
+// GetID returns the primary key of the model.
+func (r *StoreFixture) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *StoreFixture) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "foo":
 		return &r.Foo, nil
 
@@ -4863,10 +4931,11 @@ func (r *StoreFixture) ColumnAddress(col string) (interface{}, error) {
 	}
 }
 
+// Value returns the value of the given column.
 func (r *StoreFixture) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "foo":
 		return r.Foo, nil
 
@@ -4875,10 +4944,13 @@ func (r *StoreFixture) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *StoreFixture) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model StoreFixture has no relationships")
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *StoreFixture) SetRelationship(field string, rel interface{}) error {
 	return fmt.Errorf("kallax: model StoreFixture has no relationships")
 }
@@ -5199,17 +5271,19 @@ func (rs *StoreFixtureResultSet) Close() error {
 
 // NewStoreWithConstructFixture returns a new instance of StoreWithConstructFixture.
 func NewStoreWithConstructFixture(f string) (record *StoreWithConstructFixture) {
-	record = newStoreWithConstructFixture(f)
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newStoreWithConstructFixture(f)
 }
 
+// GetID returns the primary key of the model.
+func (r *StoreWithConstructFixture) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *StoreWithConstructFixture) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "foo":
 		return &r.Foo, nil
 
@@ -5218,10 +5292,11 @@ func (r *StoreWithConstructFixture) ColumnAddress(col string) (interface{}, erro
 	}
 }
 
+// Value returns the value of the given column.
 func (r *StoreWithConstructFixture) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "foo":
 		return r.Foo, nil
 
@@ -5230,10 +5305,13 @@ func (r *StoreWithConstructFixture) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *StoreWithConstructFixture) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model StoreWithConstructFixture has no relationships")
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *StoreWithConstructFixture) SetRelationship(field string, rel interface{}) error {
 	return fmt.Errorf("kallax: model StoreWithConstructFixture has no relationships")
 }
@@ -5554,17 +5632,19 @@ func (rs *StoreWithConstructFixtureResultSet) Close() error {
 
 // NewStoreWithNewFixture returns a new instance of StoreWithNewFixture.
 func NewStoreWithNewFixture() (record *StoreWithNewFixture) {
-	record = &StoreWithNewFixture{}
-	if record != nil {
-		record.SetID(kallax.NewID())
-	}
-	return
+	return newStoreWithNewFixture()
 }
 
+// GetID returns the primary key of the model.
+func (r *StoreWithNewFixture) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
 func (r *StoreWithNewFixture) ColumnAddress(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return &r.Model.ID, nil
+		return (*kallax.ULID)(&r.ID), nil
 	case "foo":
 		return &r.Foo, nil
 	case "bar":
@@ -5575,10 +5655,11 @@ func (r *StoreWithNewFixture) ColumnAddress(col string) (interface{}, error) {
 	}
 }
 
+// Value returns the value of the given column.
 func (r *StoreWithNewFixture) Value(col string) (interface{}, error) {
 	switch col {
 	case "id":
-		return r.Model.ID, nil
+		return r.ID, nil
 	case "foo":
 		return r.Foo, nil
 	case "bar":
@@ -5589,10 +5670,13 @@ func (r *StoreWithNewFixture) Value(col string) (interface{}, error) {
 	}
 }
 
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
 func (r *StoreWithNewFixture) NewRelationshipRecord(field string) (kallax.Record, error) {
 	return nil, fmt.Errorf("kallax: model StoreWithNewFixture has no relationships")
 }
 
+// SetRelationship sets the given relationship in the given field.
 func (r *StoreWithNewFixture) SetRelationship(field string, rel interface{}) error {
 	return fmt.Errorf("kallax: model StoreWithNewFixture has no relationships")
 }
@@ -6076,6 +6160,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(Car)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("owner_id"),
 			kallax.NewSchemaField("model_name"),
@@ -6092,6 +6177,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(EventsAllFixture)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("checks"),
 			kallax.NewSchemaField("must_fail_before"),
@@ -6111,6 +6197,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(EventsFixture)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("checks"),
 			kallax.NewSchemaField("must_fail_before"),
@@ -6130,6 +6217,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(EventsSaveFixture)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("checks"),
 			kallax.NewSchemaField("must_fail_before"),
@@ -6149,6 +6237,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(JSONModel)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("foo"),
 			kallax.NewSchemaField("bar"),
@@ -6182,6 +6271,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(MultiKeySortFixture)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("name"),
 			kallax.NewSchemaField("start"),
@@ -6204,6 +6294,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(Person)
 			},
+			true,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("name"),
 		),
@@ -6221,6 +6312,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(Pet)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("name"),
 			kallax.NewSchemaField("kind"),
@@ -6239,6 +6331,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(QueryFixture)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("foo"),
 		),
@@ -6254,6 +6347,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(ResultSetFixture)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("foo"),
 		),
@@ -6271,6 +6365,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(SchemaFixture)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("string"),
 			kallax.NewSchemaField("int"),
@@ -6296,6 +6391,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(StoreFixture)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("foo"),
 		),
@@ -6311,6 +6407,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(StoreWithConstructFixture)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("foo"),
 		),
@@ -6326,6 +6423,7 @@ var Schema = &schema{
 			func() kallax.Record {
 				return new(StoreWithNewFixture)
 			},
+			false,
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("foo"),
 			kallax.NewSchemaField("bar"),

--- a/tests/query.go
+++ b/tests/query.go
@@ -4,9 +4,10 @@ import "github.com/src-d/go-kallax"
 
 type QueryFixture struct {
 	kallax.Model `table:"query"`
+	ID           kallax.ULID `pk:""`
 	Foo          string
 }
 
 func newQueryFixture(f string) *QueryFixture {
-	return &QueryFixture{Foo: f}
+	return &QueryFixture{ID: kallax.NewULID(), Foo: f}
 }

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -33,7 +33,7 @@ func (s *QuerySuite) TestQuery() {
 		s.Equal("bar", store.MustFindOne(query).Foo)
 	})
 
-	notID := kallax.NewID()
+	notID := kallax.NewULID()
 	queryErr := NewQueryFixtureQuery()
 	queryErr.Where(kallax.Eq(Schema.QueryFixture.ID, notID))
 	s.Panics(func() {

--- a/tests/relationships.go
+++ b/tests/relationships.go
@@ -4,7 +4,8 @@ import kallax "github.com/src-d/go-kallax"
 
 type Car struct {
 	kallax.Model `table:"cars"`
-	Owner        *Person `fk:"owner_id,inverse"`
+	ID           kallax.ULID `pk:""`
+	Owner        *Person     `fk:"owner_id,inverse"`
 	ModelName    string
 	events       map[string]int
 }
@@ -41,6 +42,7 @@ func (c *Car) AfterDelete() error {
 
 type Person struct {
 	kallax.Model `table:"persons"`
+	ID           int64 `pk:"autoincr"`
 	Name         string
 	Pets         []*Pet `fk:"owner_id"`
 	Car          *Car   `fk:"owner_id"`
@@ -79,6 +81,7 @@ func (c *Person) AfterDelete() error {
 
 type Pet struct {
 	kallax.Model `table:"pets"`
+	ID           kallax.ULID `pk:""`
 	Name         string
 	Kind         string
 	Owner        *Person `fk:"owner_id,inverse"`
@@ -116,7 +119,7 @@ func (c *Pet) AfterDelete() error {
 }
 
 func newPet(name, kind string, owner *Person) *Pet {
-	pet := &Pet{Name: name, Kind: kind, Owner: owner}
+	pet := &Pet{ID: kallax.NewULID(), Name: name, Kind: kind, Owner: owner}
 	owner.Pets = append(owner.Pets, pet)
 	return pet
 }
@@ -126,7 +129,7 @@ func newPerson(name string) *Person {
 }
 
 func newCar(model string, owner *Person) *Car {
-	car := &Car{ModelName: model, Owner: owner}
+	car := &Car{ID: kallax.NewULID(), ModelName: model, Owner: owner}
 	owner.Car = car
 	return car
 }

--- a/tests/relationships_test.go
+++ b/tests/relationships_test.go
@@ -13,19 +13,19 @@ type RelationshipsSuite struct {
 func TestRelationships(t *testing.T) {
 	schemas := []string{
 		`CREATE TABLE IF NOT EXISTS persons (
-			id uuid primary key,
+			id serial primary key,
 			name text
 		)`,
 		`CREATE TABLE IF NOT EXISTS cars (
 			id uuid primary key,
 			model_name text,
-			owner_id uuid references persons(id)
+			owner_id integer references persons(id)
 		)`,
 		`CREATE TABLE IF NOT EXISTS pets (
 			id uuid primary key,
 			name text,
 			kind text,
-			owner_id uuid references persons(id)
+			owner_id integer references persons(id)
 		)`,
 	}
 	suite.Run(t, &RelationshipsSuite{NewBaseSuite(schemas, "cars", "pets", "persons")})
@@ -129,6 +129,7 @@ func (s *RelationshipsSuite) assertNoEvents(evs map[string]int, events ...string
 }
 
 func (s *RelationshipsSuite) assertPerson(name string, pers *Person, car *Car, pets ...*Pet) {
+	s.False(pers.GetID().IsEmpty(), "ID should not be empty")
 	s.Equal(name, pers.Name)
 	pers.events = nil
 	s.Len(pers.Pets, len(pets))
@@ -140,6 +141,7 @@ func (s *RelationshipsSuite) assertPerson(name string, pers *Person, car *Car, p
 	var petList = make([]*Pet, len(pets))
 	for i, pet := range pets {
 		p := *pet
+		s.False(p.GetID().IsEmpty(), "ID should not be empty")
 		p.Owner = nil
 		p.events = nil
 		petList[i] = &p
@@ -150,6 +152,7 @@ func (s *RelationshipsSuite) assertPerson(name string, pers *Person, car *Car, p
 		s.Nil(pers.Car)
 	} else {
 		c = *car
+		s.False(c.GetID().IsEmpty(), "ID should not be empty")
 		c.Owner = nil
 		c.events = nil
 		s.Equal(&c, pers.Car)

--- a/tests/resultset.go
+++ b/tests/resultset.go
@@ -4,9 +4,10 @@ import "github.com/src-d/go-kallax"
 
 type ResultSetFixture struct {
 	kallax.Model `table:"resultset"`
+	ID           kallax.ULID `pk:""`
 	Foo          string
 }
 
 func newResultSetFixture(f string) *ResultSetFixture {
-	return &ResultSetFixture{Foo: f}
+	return &ResultSetFixture{ID: kallax.NewULID(), Foo: f}
 }

--- a/tests/schema.go
+++ b/tests/schema.go
@@ -4,7 +4,8 @@ import "github.com/src-d/go-kallax"
 
 type SchemaFixture struct {
 	kallax.Model `table:"schema"`
-	ShouldIgnore string `kallax:"-"`
+	ID           kallax.ULID `pk:""`
+	ShouldIgnore string      `kallax:"-"`
 	String       string
 	Int          int
 	Nested       *SchemaFixture
@@ -16,4 +17,8 @@ type SchemaFixture struct {
 	MapOfSomeType  map[string]struct {
 		Foo string
 	}
+}
+
+func newSchemaFixture() *SchemaFixture {
+	return &SchemaFixture{ID: kallax.NewULID()}
 }

--- a/tests/store.go
+++ b/tests/store.go
@@ -8,11 +8,17 @@ import (
 
 type StoreFixture struct {
 	kallax.Model `table:"store"`
+	ID           kallax.ULID `pk:""`
 	Foo          string
+}
+
+func newStoreFixture() *StoreFixture {
+	return &StoreFixture{ID: kallax.NewULID()}
 }
 
 type StoreWithConstructFixture struct {
 	kallax.Model `table:"store_construct"`
+	ID           kallax.ULID `pk:""`
 	Foo          string
 }
 
@@ -20,18 +26,28 @@ func newStoreWithConstructFixture(f string) *StoreWithConstructFixture {
 	if f == "" {
 		return nil
 	}
-	return &StoreWithConstructFixture{Foo: f}
+	return &StoreWithConstructFixture{ID: kallax.NewULID(), Foo: f}
 }
 
 type StoreWithNewFixture struct {
 	kallax.Model `table:"store_new"`
+	ID           kallax.ULID `pk:""`
 	Foo          string
 	Bar          string
 }
 
+func newStoreWithNewFixture() *StoreWithNewFixture {
+	return &StoreWithNewFixture{ID: kallax.NewULID()}
+}
+
 type MultiKeySortFixture struct {
 	kallax.Model `table:"query"`
+	ID           kallax.ULID `pk:""`
 	Name         string
 	Start        time.Time
 	End          time.Time
+}
+
+func newMultiKeySortFixture() *MultiKeySortFixture {
+	return &MultiKeySortFixture{ID: kallax.NewULID()}
 }

--- a/tests/store_test.go
+++ b/tests/store_test.go
@@ -71,7 +71,7 @@ func (s *StoreSuite) TestStoreFindOneReturnValues() {
 	s.Nil(store.Insert(NewStoreWithConstructFixture("bar")))
 
 	notFoundQuery := NewStoreWithConstructFixtureQuery()
-	notFoundQuery.Where(kallax.Eq(Schema.ResultSetFixture.ID, kallax.NewID()))
+	notFoundQuery.Where(kallax.Eq(Schema.ResultSetFixture.ID, kallax.NewULID()))
 	doc, err := store.FindOne(notFoundQuery)
 	s.resultOrError(doc, err)
 


### PR DESCRIPTION
Still a WIP, missing tests and all, but just to validate the API and the changes.

(fear not, most of the changes are generated kallax.go changes)

### Considerations

Is not totally customizable, only these types are allowed:
- `int64`
- `uuid.UUID`
- `kallax.UUID`
- `kallax.ULID`
- `kallax.NumericID`