### PR TITLE
fix: ensure nullable types work correctly with pointer types

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -27,7 +27,7 @@ func openTestDB() (*sql.DB, error) {
 }
 
 func setupTables(t *testing.T, db *sql.DB) {
-	_, err := db.Exec(`CREATE TABLE model (
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS model (
 		id serial PRIMARY KEY,
 		name varchar(255) not null,
 		email varchar(255) not null,
@@ -35,7 +35,7 @@ func setupTables(t *testing.T, db *sql.DB) {
 	)`)
 	require.NoError(t, err)
 
-	_, err = db.Exec(`CREATE TABLE rel (
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS rel (
 		id serial PRIMARY KEY,
 		model_id integer,
 		foo text

--- a/generator/processor_test.go
+++ b/generator/processor_test.go
@@ -225,7 +225,7 @@ func (s *ProcessorSuite) TestProcessField() {
 		{"ComplexArray", Array, true, false, false},
 		{"InlineArray", Struct, true, false, false},
 		{"Interface", Interface, true, false, false},
-		{"SQLInterface", Interface, true, false, false}, // TODO false, false, falseº
+		{"SQLInterface", Interface, true, false, false}, // TODO false, false, false
 	}
 
 	m := findModel(pkg, "Foo")

--- a/generator/template.go
+++ b/generator/template.go
@@ -73,7 +73,7 @@ func (td *TemplateData) genFieldsColumnAddresses(buf *bytes.Buffer, fields []*Fi
 				if f.IsJSON && f.IsPtr {
 					buf.WriteString(fmt.Sprintf(initNilPtrTpl, f.Name, f.Name, td.GenTypeName(f)))
 				}
-				buf.WriteString(fmt.Sprintf("return %s\n", f.Address()))
+				buf.WriteString(fmt.Sprintf("return %s, nil\n", f.Address()))
 			}
 		}
 	}

--- a/generator/template.go
+++ b/generator/template.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"go/build"
+	"go/types"
 	"io"
 	"os"
 	"path/filepath"
@@ -70,7 +71,7 @@ func (td *TemplateData) genFieldsColumnAddresses(buf *bytes.Buffer, fields []*Fi
 				buf.WriteString(fmt.Sprintf("return (*%s)(%s), nil\n", td.IdentifierType(f), f.fieldVarAddress()))
 			} else {
 				// can't scan a json if is nil
-				if f.IsJSON && f.IsPtr {
+				if (f.IsJSON || f.Kind == Interface) && f.IsPtr {
 					buf.WriteString(fmt.Sprintf(initNilPtrTpl, f.Name, f.Name, td.GenTypeName(f)))
 				}
 				buf.WriteString(fmt.Sprintf("return %s, nil\n", f.Address()))
@@ -96,6 +97,11 @@ func (td *TemplateData) GenColumnValues(model *Model) string {
 	return buf.String()
 }
 
+const nilPtrReturnsUntypedNilTpl = `if %s == (*%s)(nil) {
+	return nil, nil
+}
+`
+
 func (td *TemplateData) genFieldsValues(buf *bytes.Buffer, fields []*Field) {
 	for _, f := range fields {
 		if f.Inline() {
@@ -105,6 +111,9 @@ func (td *TemplateData) genFieldsValues(buf *bytes.Buffer, fields []*Field) {
 			buf.WriteString(fmt.Sprintf("return r.Model.VirtualColumn(col), nil\n"))
 		} else if f.Kind != Relationship {
 			buf.WriteString(fmt.Sprintf("case \"%s\":\n", f.ColumnName()))
+			if f.IsPtr {
+				buf.WriteString(fmt.Sprintf(nilPtrReturnsUntypedNilTpl, f.fieldVarName(), td.GenTypeName(f)))
+			}
 			buf.WriteString(fmt.Sprintf("return %s\n", f.Value()))
 		}
 	}
@@ -178,7 +187,26 @@ func (td *TemplateData) findJSONSchemas(parent string, f *Field) {
 
 // GenTypeName generates the name of the type in the field.
 func (td *TemplateData) GenTypeName(f *Field) string {
+	if name, ok := findNamed(f.Node.Type(), td.pkg); ok {
+		return name
+	}
+
 	return removeTypePrefix(typeString(f.Node.Type(), td.pkg))
+}
+
+func findNamed(t types.Type, pkg *types.Package) (string, bool) {
+	switch t := t.(type) {
+	case *types.Pointer:
+		return findNamed(t.Elem(), pkg)
+	case *types.Named:
+		if t.Obj().Pkg().Path() == pkg.Path() {
+			return t.Obj().Name(), true
+		}
+
+		return fmt.Sprintf("%s.%s", t.Obj().Pkg().Name(), t.Obj().Name()), true
+	default:
+		return "", false
+	}
 }
 
 // IsPtrSlice returns whether the field is a slice of pointers or not.

--- a/generator/template_test.go
+++ b/generator/template_test.go
@@ -47,7 +47,7 @@ return (*kallax.NumericID)(&r.ID), nil
 case "foo":
 return &r.Foo, nil
 case "bar":
-return r.Bar, nil
+return types.Nullable(&r.Bar), nil
 case "arr":
 return types.Slice(&r.Arr), nil
 case "json":

--- a/generator/template_test.go
+++ b/generator/template_test.go
@@ -103,6 +103,9 @@ return r.ID, nil
 case "foo":
 return r.Foo, nil
 case "bar":
+if r.Bar == (*string)(nil) {
+	return nil, nil
+}
 return r.Bar, nil
 case "aliased":
 return (string)(r.Aliased), nil
@@ -111,6 +114,9 @@ return types.Slice(r.Arr), nil
 case "json":
 return types.JSON(r.JSON), nil
 case "url":
+if r.URL == (*url.URL)(nil) {
+	return nil, nil
+}
 return (*types.URL)(r.URL), nil
 case "url_no_ptr":
 return (*types.URL)(&r.UrlNoPtr), nil

--- a/generator/types.go
+++ b/generator/types.go
@@ -677,27 +677,33 @@ func (f *Field) fieldVarAddress() string {
 // pointer to the field.
 func (f *Field) Address() string {
 	name := f.fieldVarAddress()
+	var casted bool
 	if mapped, ok := mappings[f.Type]; ok {
 		name = fmt.Sprintf("(*%s)(%s)", mapped, name)
+		casted = true
 	}
 
-	return f.wrapAddress(name)
+	return f.wrapAddress(name, casted)
 }
 
-func (f *Field) wrapAddress(ptr string) string {
+func (f *Field) wrapAddress(ptr string, casted bool) string {
 	if f.IsJSON {
-		return fmt.Sprintf("types.JSON(%s), nil", ptr)
+		return fmt.Sprintf("types.JSON(%s)", ptr)
 	}
 
 	if f.Kind == Slice {
-		return fmt.Sprintf("types.Slice(%s), nil", ptr)
+		return fmt.Sprintf("types.Slice(%s)", ptr)
 	}
 
 	if f.Kind == Array {
-		return fmt.Sprintf("types.Array(%s, %d), nil", ptr, arrayLen(f))
+		return fmt.Sprintf("types.Array(%s, %d)", ptr, arrayLen(f))
 	}
 
-	return fmt.Sprintf("%s, nil", ptr)
+	if f.IsPtr && !casted {
+		return fmt.Sprintf("types.Nullable(&%s)", ptr)
+	}
+
+	return ptr
 }
 
 // Value is the string representation of the code needed to get the value of

--- a/generator/types.go
+++ b/generator/types.go
@@ -700,6 +700,9 @@ func (f *Field) wrapAddress(ptr string, casted bool) string {
 	}
 
 	if f.IsPtr && !casted {
+		if f.Kind == Interface {
+			return fmt.Sprintf("types.Nullable(%s)", ptr)
+		}
 		return fmt.Sprintf("types.Nullable(&%s)", ptr)
 	}
 

--- a/generator/types_test.go
+++ b/generator/types_test.go
@@ -131,6 +131,10 @@ func (s *FieldSuite) TestAddress() {
 			"types.Nullable(&r.Foo)",
 		},
 		{
+			Interface, false, true, "Foo", "", nil,
+			"types.Nullable(r.Foo)",
+		},
+		{
 			Basic, false, true, "Foo", "", withParent(mkField("Bar", ""), mkField("Baz", "")),
 			"types.Nullable(&r.Baz.Bar.Foo)",
 		},

--- a/generator/types_test.go
+++ b/generator/types_test.go
@@ -108,31 +108,31 @@ func (s *FieldSuite) TestAddress() {
 	}{
 		{
 			Struct, true, false, "Foo", "", nil,
-			"types.JSON(&r.Foo), nil",
+			"types.JSON(&r.Foo)",
 		},
 		{
 			Map, true, false, "Foo", "", nil,
-			"types.JSON(&r.Foo), nil",
+			"types.JSON(&r.Foo)",
 		},
 		{
 			Struct, false, false, "Foo", "", nil,
-			"&r.Foo, nil",
+			"&r.Foo",
 		},
 		{
 			Array, false, false, "Foo", "[5]string", nil,
-			`types.Array(&r.Foo, 5), nil`,
+			`types.Array(&r.Foo, 5)`,
 		},
 		{
 			Slice, false, false, "Foo", "", nil,
-			"types.Slice(&r.Foo), nil",
+			"types.Slice(&r.Foo)",
 		},
 		{
 			Basic, false, true, "Foo", "", nil,
-			"r.Foo, nil",
+			"types.Nullable(&r.Foo)",
 		},
 		{
 			Basic, false, true, "Foo", "", withParent(mkField("Bar", ""), mkField("Baz", "")),
-			"r.Baz.Bar.Foo, nil",
+			"types.Nullable(&r.Baz.Bar.Foo)",
 		},
 	}
 

--- a/resultset.go
+++ b/resultset.go
@@ -74,6 +74,7 @@ func (rs *BaseResultSet) Scan(record Record) error {
 		if err != nil {
 			return err
 		}
+
 		pointers[i] = ptr
 	}
 

--- a/tests/kallax.go
+++ b/tests/kallax.go
@@ -2498,6 +2498,367 @@ func (rs *MultiKeySortFixtureResultSet) Close() error {
 	return rs.ResultSet.Close()
 }
 
+// NewNullable returns a new instance of Nullable.
+func NewNullable() (record *Nullable) {
+	return new(Nullable)
+}
+
+// GetID returns the primary key of the model.
+func (r *Nullable) GetID() kallax.Identifier {
+	return (*kallax.NumericID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
+func (r *Nullable) ColumnAddress(col string) (interface{}, error) {
+	switch col {
+	case "id":
+		return (*kallax.NumericID)(&r.ID), nil
+	case "t":
+		return types.Nullable(&r.T), nil
+
+	default:
+		return nil, fmt.Errorf("kallax: invalid column in Nullable: %s", col)
+	}
+}
+
+// Value returns the value of the given column.
+func (r *Nullable) Value(col string) (interface{}, error) {
+	switch col {
+	case "id":
+		return r.ID, nil
+	case "t":
+		return r.T, nil
+
+	default:
+		return nil, fmt.Errorf("kallax: invalid column in Nullable: %s", col)
+	}
+}
+
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
+func (r *Nullable) NewRelationshipRecord(field string) (kallax.Record, error) {
+	return nil, fmt.Errorf("kallax: model Nullable has no relationships")
+}
+
+// SetRelationship sets the given relationship in the given field.
+func (r *Nullable) SetRelationship(field string, rel interface{}) error {
+	return fmt.Errorf("kallax: model Nullable has no relationships")
+}
+
+// NullableStore is the entity to access the records of the type Nullable
+// in the database.
+type NullableStore struct {
+	*kallax.Store
+}
+
+// NewNullableStore creates a new instance of NullableStore
+// using a SQL database.
+func NewNullableStore(db *sql.DB) *NullableStore {
+	return &NullableStore{kallax.NewStore(db)}
+}
+
+// Insert inserts a Nullable in the database. A non-persisted object is
+// required for this operation.
+func (s *NullableStore) Insert(record *Nullable) error {
+
+	return s.Store.Insert(Schema.Nullable.BaseSchema, record)
+
+}
+
+// Update updates the given record on the database. If the columns are given,
+// only these columns will be updated. Otherwise all of them will be.
+// Be very careful with this, as you will have a potentially different object
+// in memory but not on the database.
+// Only writable records can be updated. Writable objects are those that have
+// been just inserted or retrieved using a query with no custom select fields.
+func (s *NullableStore) Update(record *Nullable, cols ...kallax.SchemaField) (updated int64, err error) {
+
+	return s.Store.Update(Schema.Nullable.BaseSchema, record, cols...)
+
+}
+
+// Save inserts the object if the record is not persisted, otherwise it updates
+// it. Same rules of Update and Insert apply depending on the case.
+func (s *NullableStore) Save(record *Nullable) (updated bool, err error) {
+	if !record.IsPersisted() {
+		return false, s.Insert(record)
+	}
+
+	rowsUpdated, err := s.Update(record)
+	if err != nil {
+		return false, err
+	}
+
+	return rowsUpdated > 0, nil
+}
+
+// Delete removes the given record from the database.
+func (s *NullableStore) Delete(record *Nullable) error {
+
+	return s.Store.Delete(Schema.Nullable.BaseSchema, record)
+
+}
+
+// Find returns the set of results for the given query.
+func (s *NullableStore) Find(q *NullableQuery) (*NullableResultSet, error) {
+	rs, err := s.Store.Find(q)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewNullableResultSet(rs), nil
+}
+
+// MustFind returns the set of results for the given query, but panics if there
+// is any error.
+func (s *NullableStore) MustFind(q *NullableQuery) *NullableResultSet {
+	return NewNullableResultSet(s.Store.MustFind(q))
+}
+
+// Count returns the number of rows that would be retrieved with the given
+// query.
+func (s *NullableStore) Count(q *NullableQuery) (int64, error) {
+	return s.Store.Count(q)
+}
+
+// MustCount returns the number of rows that would be retrieved with the given
+// query, but panics if there is an error.
+func (s *NullableStore) MustCount(q *NullableQuery) int64 {
+	return s.Store.MustCount(q)
+}
+
+// FindOne returns the first row returned by the given query.
+// `ErrNotFound` is returned if there are no results.
+func (s *NullableStore) FindOne(q *NullableQuery) (*Nullable, error) {
+	q.Limit(1)
+	q.Offset(0)
+	rs, err := s.Find(q)
+	if err != nil {
+		return nil, err
+	}
+
+	if !rs.Next() {
+		return nil, kallax.ErrNotFound
+	}
+
+	record, err := rs.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := rs.Close(); err != nil {
+		return nil, err
+	}
+
+	return record, nil
+}
+
+// MustFindOne returns the first row retrieved by the given query. It panics
+// if there is an error or if there are no rows.
+func (s *NullableStore) MustFindOne(q *NullableQuery) *Nullable {
+	record, err := s.FindOne(q)
+	if err != nil {
+		panic(err)
+	}
+	return record
+}
+
+// Reload refreshes the Nullable with the data in the database and
+// makes it writable.
+func (s *NullableStore) Reload(record *Nullable) error {
+	return s.Store.Reload(Schema.Nullable.BaseSchema, record)
+}
+
+// Transaction executes the given callback in a transaction and rollbacks if
+// an error is returned.
+// The transaction is only open in the store passed as a parameter to the
+// callback.
+func (s *NullableStore) Transaction(callback func(*NullableStore) error) error {
+	if callback == nil {
+		return kallax.ErrInvalidTxCallback
+	}
+
+	return s.Store.Transaction(func(store *kallax.Store) error {
+		return callback(&NullableStore{store})
+	})
+}
+
+// NullableQuery is the object used to create queries for the Nullable
+// entity.
+type NullableQuery struct {
+	*kallax.BaseQuery
+}
+
+// NewNullableQuery returns a new instance of NullableQuery.
+func NewNullableQuery() *NullableQuery {
+	return &NullableQuery{
+		BaseQuery: kallax.NewBaseQuery(Schema.Nullable.BaseSchema),
+	}
+}
+
+// Select adds columns to select in the query.
+func (q *NullableQuery) Select(columns ...kallax.SchemaField) *NullableQuery {
+	if len(columns) == 0 {
+		return q
+	}
+	q.BaseQuery.Select(columns...)
+	return q
+}
+
+// SelectNot excludes columns from being selected in the query.
+func (q *NullableQuery) SelectNot(columns ...kallax.SchemaField) *NullableQuery {
+	q.BaseQuery.SelectNot(columns...)
+	return q
+}
+
+// Copy returns a new identical copy of the query. Remember queries are mutable
+// so make a copy any time you need to reuse them.
+func (q *NullableQuery) Copy() *NullableQuery {
+	return &NullableQuery{
+		BaseQuery: q.BaseQuery.Copy(),
+	}
+}
+
+// Order adds order clauses to the query for the given columns.
+func (q *NullableQuery) Order(cols ...kallax.ColumnOrder) *NullableQuery {
+	q.BaseQuery.Order(cols...)
+	return q
+}
+
+// BatchSize sets the number of items to fetch per batch when there are 1:N
+// relationships selected in the query.
+func (q *NullableQuery) BatchSize(size uint64) *NullableQuery {
+	q.BaseQuery.BatchSize(size)
+	return q
+}
+
+// Limit sets the max number of items to retrieve.
+func (q *NullableQuery) Limit(n uint64) *NullableQuery {
+	q.BaseQuery.Limit(n)
+	return q
+}
+
+// Offset sets the number of items to skip from the result set of items.
+func (q *NullableQuery) Offset(n uint64) *NullableQuery {
+	q.BaseQuery.Offset(n)
+	return q
+}
+
+// Where adds a condition to the query. All conditions added are concatenated
+// using a logical AND.
+func (q *NullableQuery) Where(cond kallax.Condition) *NullableQuery {
+	q.BaseQuery.Where(cond)
+	return q
+}
+
+// NullableResultSet is the set of results returned by a query to the
+// database.
+type NullableResultSet struct {
+	ResultSet kallax.ResultSet
+	last      *Nullable
+	lastErr   error
+}
+
+// NewNullableResultSet creates a new result set for rows of the type
+// Nullable.
+func NewNullableResultSet(rs kallax.ResultSet) *NullableResultSet {
+	return &NullableResultSet{ResultSet: rs}
+}
+
+// Next fetches the next item in the result set and returns true if there is
+// a next item.
+// The result set is closed automatically when there are no more items.
+func (rs *NullableResultSet) Next() bool {
+	if !rs.ResultSet.Next() {
+		rs.lastErr = rs.ResultSet.Close()
+		rs.last = nil
+		return false
+	}
+
+	var record kallax.Record
+	record, rs.lastErr = rs.ResultSet.Get(Schema.Nullable.BaseSchema)
+	if rs.lastErr != nil {
+		rs.last = nil
+	} else {
+		var ok bool
+		rs.last, ok = record.(*Nullable)
+		if !ok {
+			rs.lastErr = fmt.Errorf("kallax: unable to convert record to *Nullable")
+			rs.last = nil
+		}
+	}
+
+	return true
+}
+
+// Get retrieves the last fetched item from the result set and the last error.
+func (rs *NullableResultSet) Get() (*Nullable, error) {
+	return rs.last, rs.lastErr
+}
+
+// ForEach iterates over the complete result set passing every record found to
+// the given callback. It is possible to stop the iteration by returning
+// `kallax.ErrStop` in the callback.
+// Result set is always closed at the end.
+func (rs *NullableResultSet) ForEach(fn func(*Nullable) error) error {
+	for rs.Next() {
+		record, err := rs.Get()
+		if err != nil {
+			return err
+		}
+
+		if err := fn(record); err != nil {
+			if err == kallax.ErrStop {
+				return rs.Close()
+			}
+
+			return err
+		}
+	}
+	return nil
+}
+
+// All returns all records on the result set and closes the result set.
+func (rs *NullableResultSet) All() ([]*Nullable, error) {
+	var result []*Nullable
+	for rs.Next() {
+		record, err := rs.Get()
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, record)
+	}
+	return result, nil
+}
+
+// One returns the first record on the result set and closes the result set.
+func (rs *NullableResultSet) One() (*Nullable, error) {
+	if !rs.Next() {
+		return nil, kallax.ErrNotFound
+	}
+
+	record, err := rs.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := rs.Close(); err != nil {
+		return nil, err
+	}
+
+	return record, nil
+}
+
+// Err returns the last error occurred.
+func (rs *NullableResultSet) Err() error {
+	return rs.lastErr
+}
+
+// Close closes the result set.
+func (rs *NullableResultSet) Close() error {
+	return rs.ResultSet.Close()
+}
+
 // NewPerson returns a new instance of Person.
 func NewPerson(name string) (record *Person) {
 	return newPerson(name)
@@ -6002,6 +6363,7 @@ type schema struct {
 	EventsSaveFixture         *schemaEventsSaveFixture
 	JSONModel                 *schemaJSONModel
 	MultiKeySortFixture       *schemaMultiKeySortFixture
+	Nullable                  *schemaNullable
 	Person                    *schemaPerson
 	Pet                       *schemaPet
 	QueryFixture              *schemaQueryFixture
@@ -6057,6 +6419,12 @@ type schemaMultiKeySortFixture struct {
 	Name  kallax.SchemaField
 	Start kallax.SchemaField
 	End   kallax.SchemaField
+}
+
+type schemaNullable struct {
+	*kallax.BaseSchema
+	ID kallax.SchemaField
+	T  kallax.SchemaField
 }
 
 type schemaPerson struct {
@@ -6281,6 +6649,22 @@ var Schema = &schema{
 		Name:  kallax.NewSchemaField("name"),
 		Start: kallax.NewSchemaField("start"),
 		End:   kallax.NewSchemaField("_end"),
+	},
+	Nullable: &schemaNullable{
+		BaseSchema: kallax.NewBaseSchema(
+			"nullable",
+			"__nullable",
+			kallax.NewSchemaField("id"),
+			kallax.ForeignKeys{},
+			func() kallax.Record {
+				return new(Nullable)
+			},
+			true,
+			kallax.NewSchemaField("id"),
+			kallax.NewSchemaField("t"),
+		),
+		ID: kallax.NewSchemaField("id"),
+		T:  kallax.NewSchemaField("t"),
 	},
 	Person: &schemaPerson{
 		BaseSchema: kallax.NewBaseSchema(

--- a/tests/store.go
+++ b/tests/store.go
@@ -52,8 +52,14 @@ func newMultiKeySortFixture() *MultiKeySortFixture {
 	return &MultiKeySortFixture{ID: kallax.NewULID()}
 }
 
+type SomeJSON struct {
+	Foo int
+}
+
 type Nullable struct {
 	kallax.Model `table:"nullable"`
 	ID           int64 `pk:"autoincr"`
 	T            *time.Time
+	SomeJSON     *SomeJSON
+	Scanner      *kallax.ULID
 }

--- a/tests/store.go
+++ b/tests/store.go
@@ -51,3 +51,9 @@ type MultiKeySortFixture struct {
 func newMultiKeySortFixture() *MultiKeySortFixture {
 	return &MultiKeySortFixture{ID: kallax.NewULID()}
 }
+
+type Nullable struct {
+	kallax.Model `table:"nullable"`
+	ID           int64 `pk:"autoincr"`
+	T            *time.Time
+}

--- a/tests/store_test.go
+++ b/tests/store_test.go
@@ -31,7 +31,9 @@ func TestStoreSuite(t *testing.T) {
 		)`,
 		`CREATE TABLE IF NOT EXISTS nullable (
 			id serial primary key,
-			t timestamptz
+			t timestamptz,
+			some_json jsonb,
+			scanner uuid
 		)`,
 	}
 	suite.Run(t, &StoreSuite{NewBaseSuite(schema, "store_construct", "store", "store_new", "query", "nullable")})

--- a/types/types.go
+++ b/types/types.go
@@ -64,6 +64,38 @@ func Nullable(typ interface{}) sql.Scanner {
 		return &nullDuration{typ}
 	case sql.Scanner:
 		return &nullable{typ}
+	case **string:
+		return &nullPtrString{typ}
+	case **bool:
+		return &nullPtrBool{typ}
+	case **int8:
+		return &nullPtrInt8{typ}
+	case **uint8:
+		return &nullPtrUint8{typ}
+	case **int16:
+		return &nullPtrInt16{typ}
+	case **uint16:
+		return &nullPtrUint16{typ}
+	case **uint:
+		return &nullPtrUint{typ}
+	case **int:
+		return &nullPtrInt{typ}
+	case **uint32:
+		return &nullPtrUint32{typ}
+	case **int32:
+		return &nullPtrInt32{typ}
+	case **uint64:
+		return &nullPtrUint64{typ}
+	case **int64:
+		return &nullPtrInt64{typ}
+	case **float32:
+		return &nullPtrFloat32{typ}
+	case **float64:
+		return &nullPtrFloat64{typ}
+	case **time.Time:
+		return &nullPtrTime{typ}
+	case **time.Duration:
+		return &nullPtrDuration{typ}
 	}
 
 	return &nullableErr{typ}
@@ -88,6 +120,321 @@ func (n *nullable) Scan(v interface{}) error {
 	return n.typ.Scan(v)
 }
 
+type nullPtrString struct {
+	v **string
+}
+
+func (n *nullPtrString) Scan(v interface{}) error {
+	ns := new(sql.NullString)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		*n.v = &ns.String
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrBool struct {
+	v **bool
+}
+
+func (n *nullPtrBool) Scan(v interface{}) error {
+	ns := new(sql.NullBool)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		*n.v = &ns.Bool
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrInt8 struct {
+	v **int8
+}
+
+func (n *nullPtrInt8) Scan(v interface{}) error {
+	ns := new(sql.NullInt64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		v := int8(ns.Int64)
+		*n.v = &v
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrUint8 struct {
+	v **uint8
+}
+
+func (n *nullPtrUint8) Scan(v interface{}) error {
+	ns := new(sql.NullInt64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		v := uint8(ns.Int64)
+		*n.v = &v
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrInt16 struct {
+	v **int16
+}
+
+func (n *nullPtrInt16) Scan(v interface{}) error {
+	ns := new(sql.NullInt64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		v := int16(ns.Int64)
+		*n.v = &v
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrUint16 struct {
+	v **uint16
+}
+
+func (n *nullPtrUint16) Scan(v interface{}) error {
+	ns := new(sql.NullInt64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		v := uint16(ns.Int64)
+		*n.v = &v
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrInt32 struct {
+	v **int32
+}
+
+func (n *nullPtrInt32) Scan(v interface{}) error {
+	ns := new(sql.NullInt64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		v := int32(ns.Int64)
+		*n.v = &v
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrUint32 struct {
+	v **uint32
+}
+
+func (n *nullPtrUint32) Scan(v interface{}) error {
+	ns := new(sql.NullInt64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		v := uint32(ns.Int64)
+		*n.v = &v
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrInt struct {
+	v **int
+}
+
+func (n *nullPtrInt) Scan(v interface{}) error {
+	ns := new(sql.NullInt64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		v := int(ns.Int64)
+		*n.v = &v
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrUint struct {
+	v **uint
+}
+
+func (n *nullPtrUint) Scan(v interface{}) error {
+	ns := new(sql.NullInt64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+	// TODO: better handling of this type
+	if ns.Valid {
+		v := uint(ns.Int64)
+		*n.v = &v
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrUint64 struct {
+	v **uint64
+}
+
+func (n *nullPtrUint64) Scan(v interface{}) error {
+	ns := new(sql.NullInt64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+	// TODO: better handling of this type
+	if ns.Valid {
+		v := uint64(ns.Int64)
+		*n.v = &v
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrInt64 struct {
+	v **int64
+}
+
+func (n *nullPtrInt64) Scan(v interface{}) error {
+	ns := new(sql.NullInt64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		*n.v = &ns.Int64
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrFloat32 struct {
+	v **float32
+}
+
+func (n *nullPtrFloat32) Scan(v interface{}) error {
+	ns := new(sql.NullFloat64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		v := float32(ns.Float64)
+		*n.v = &v
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrFloat64 struct {
+	v **float64
+}
+
+func (n *nullPtrFloat64) Scan(v interface{}) error {
+	ns := new(sql.NullFloat64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		*n.v = &ns.Float64
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrTime struct {
+	v **time.Time
+}
+
+func (n *nullPtrTime) Scan(v interface{}) error {
+	ns := new(pq.NullTime)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		*n.v = &ns.Time
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
+type nullPtrDuration struct {
+	v **time.Duration
+}
+
+func (n *nullPtrDuration) Scan(v interface{}) error {
+	ns := new(sql.NullInt64)
+	if err := ns.Scan(v); err != nil {
+		return err
+	}
+
+	if ns.Valid {
+		v := time.Duration(ns.Int64)
+		*n.v = &v
+	} else {
+		*n.v = nil
+	}
+
+	return nil
+}
+
 type nullString struct {
 	v *string
 }
@@ -97,7 +444,11 @@ func (n *nullString) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = ns.String
+
+	if ns.Valid {
+		*n.v = ns.String
+	}
+
 	return nil
 }
 
@@ -110,7 +461,11 @@ func (n *nullBool) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = ns.Bool
+
+	if ns.Valid {
+		*n.v = ns.Bool
+	}
+
 	return nil
 }
 
@@ -123,7 +478,11 @@ func (n *nullInt8) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = int8(ns.Int64)
+
+	if ns.Valid {
+		*n.v = int8(ns.Int64)
+	}
+
 	return nil
 }
 
@@ -136,7 +495,11 @@ func (n *nullUint8) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = uint8(ns.Int64)
+
+	if ns.Valid {
+		*n.v = uint8(ns.Int64)
+	}
+
 	return nil
 }
 
@@ -149,7 +512,11 @@ func (n *nullInt16) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = int16(ns.Int64)
+
+	if ns.Valid {
+		*n.v = int16(ns.Int64)
+	}
+
 	return nil
 }
 
@@ -162,7 +529,11 @@ func (n *nullUint16) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = uint16(ns.Int64)
+
+	if ns.Valid {
+		*n.v = uint16(ns.Int64)
+	}
+
 	return nil
 }
 
@@ -175,7 +546,11 @@ func (n *nullInt32) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = int32(ns.Int64)
+
+	if ns.Valid {
+		*n.v = int32(ns.Int64)
+	}
+
 	return nil
 }
 
@@ -188,7 +563,11 @@ func (n *nullUint32) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = uint32(ns.Int64)
+
+	if ns.Valid {
+		*n.v = uint32(ns.Int64)
+	}
+
 	return nil
 }
 
@@ -201,7 +580,11 @@ func (n *nullInt) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = int(ns.Int64)
+
+	if ns.Valid {
+		*n.v = int(ns.Int64)
+	}
+
 	return nil
 }
 
@@ -215,7 +598,10 @@ func (n *nullUint) Scan(v interface{}) error {
 		return err
 	}
 	// TODO: better handling of this type
-	*n.v = uint(ns.Int64)
+	if ns.Valid {
+		*n.v = uint(ns.Int64)
+	}
+
 	return nil
 }
 
@@ -229,7 +615,10 @@ func (n *nullUint64) Scan(v interface{}) error {
 		return err
 	}
 	// TODO: better handling of this type
-	*n.v = uint64(ns.Int64)
+	if ns.Valid {
+		*n.v = uint64(ns.Int64)
+	}
+
 	return nil
 }
 
@@ -242,7 +631,11 @@ func (n *nullInt64) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = ns.Int64
+
+	if ns.Valid {
+		*n.v = ns.Int64
+	}
+
 	return nil
 }
 
@@ -255,7 +648,11 @@ func (n *nullFloat32) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = float32(ns.Float64)
+
+	if ns.Valid {
+		*n.v = float32(ns.Float64)
+	}
+
 	return nil
 }
 
@@ -268,7 +665,11 @@ func (n *nullFloat64) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = ns.Float64
+
+	if ns.Valid {
+		*n.v = ns.Float64
+	}
+
 	return nil
 }
 
@@ -281,7 +682,11 @@ func (n *nullTime) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = ns.Time
+
+	if ns.Valid {
+		*n.v = ns.Time
+	}
+
 	return nil
 }
 
@@ -294,7 +699,11 @@ func (n *nullDuration) Scan(v interface{}) error {
 	if err := ns.Scan(v); err != nil {
 		return err
 	}
-	*n.v = time.Duration(ns.Int64)
+
+	if ns.Valid {
+		*n.v = time.Duration(ns.Int64)
+	}
+
 	return nil
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -800,6 +800,8 @@ func (j *sqlJSON) Scan(v interface{}) error {
 		return json.Unmarshal(v, j.val)
 	case string:
 		return j.Scan([]byte(v))
+	case nil:
+		return nil
 	}
 
 	return fmt.Errorf("kallax: cannot scan type %s into JSON type", reflect.TypeOf(v))

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -77,6 +77,10 @@ func TestJSON(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, float64(1), val.(float64))
 	})
+
+	t.Run("nil input", func(t *testing.T) {
+		require.NoError(t, JSON(&map[string]interface{}{}).Scan(nil))
+	})
 }
 
 func TestArray(t *testing.T) {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -98,24 +98,41 @@ func TestArray(t *testing.T) {
 
 func TestNullable(t *testing.T) {
 	var (
-		Str      string
-		Int8     int8
-		Uint8    uint8
-		Byte     byte
-		Int16    int16
-		Uint16   uint16
-		Int32    int32
-		Uint32   uint32
-		Int      int
-		Uint     uint
-		Int64    int64
-		Uint64   uint64
-		Float32  float32
-		Float64  float64
-		Bool     bool
-		Time     time.Time
-		Duration time.Duration
-		Url      URL
+		Str         string
+		Int8        int8
+		Uint8       uint8
+		Byte        byte
+		Int16       int16
+		Uint16      uint16
+		Int32       int32
+		Uint32      uint32
+		Int         int
+		Uint        uint
+		Int64       int64
+		Uint64      uint64
+		Float32     float32
+		Float64     float64
+		Bool        bool
+		Time        time.Time
+		Duration    time.Duration
+		Url         URL
+		PtrStr      *string
+		PtrInt8     *int8
+		PtrUint8    *uint8
+		PtrByte     *byte
+		PtrInt16    *int16
+		PtrUint16   *uint16
+		PtrInt32    *int32
+		PtrUint32   *uint32
+		PtrInt      *int
+		PtrUint     *uint
+		PtrInt64    *int64
+		PtrUint64   *uint64
+		PtrFloat32  *float32
+		PtrFloat64  *float64
+		PtrBool     *bool
+		PtrTime     *time.Time
+		PtrDuration *time.Duration
 	)
 	tim := time.Now().UTC()
 	tim = time.Date(tim.Year(), tim.Month(), tim.Day(), tim.Hour(), tim.Minute(), tim.Second(), 0, tim.Location())
@@ -128,114 +145,252 @@ func TestNullable(t *testing.T) {
 		typ          string
 		nonNullInput interface{}
 		dst          interface{}
+		isPtr        bool
 	}{
 		{
 			"string",
 			"text",
 			"foo",
 			&Str,
+			false,
 		},
 		{
 			"int8",
 			"bigint",
 			int8(1),
 			&Int8,
+			false,
 		},
 		{
 			"byte",
 			"bigint",
 			byte(1),
 			&Byte,
+			false,
 		},
 		{
 			"int16",
 			"bigint",
 			int16(1),
 			&Int16,
+			false,
 		},
 		{
 			"int32",
 			"bigint",
 			int32(1),
 			&Int32,
+			false,
 		},
 		{
 			"int",
 			"bigint",
 			int(1),
 			&Int,
+			false,
 		},
 		{
 			"int64",
 			"bigint",
 			int64(1),
 			&Int64,
+			false,
 		},
 		{
 			"uint8",
 			"bigint",
 			uint8(1),
 			&Uint8,
+			false,
 		},
 		{
 			"uint16",
 			"bigint",
 			uint16(1),
 			&Uint16,
+			false,
 		},
 		{
 			"uint32",
 			"bigint",
 			uint32(1),
 			&Uint32,
+			false,
 		},
 		{
 			"uint",
 			"bigint",
 			uint(1),
 			&Uint,
+			false,
 		},
 		{
 			"uint64",
 			"bigint",
 			uint64(1),
 			&Uint64,
+			false,
 		},
 		{
 			"float32",
 			"decimal",
 			float32(.5),
 			&Float32,
+			false,
 		},
 		{
 			"float64",
 			"decimal",
 			float64(.5),
 			&Float64,
+			false,
 		},
 		{
 			"bool",
 			"bool",
 			true,
 			&Bool,
+			false,
 		},
 		{
 			"time.Duration",
 			"bigint",
 			3 * time.Second,
 			&Duration,
+			false,
 		},
 		{
 			"time.Time",
 			"timestamptz",
 			tim,
 			&Time,
+			false,
 		},
 		{
 			"URL",
 			"text",
 			URL(*url),
 			&Url,
+			false,
+		},
+		{
+			"*string",
+			"text",
+			"foo",
+			&PtrStr,
+			true,
+		},
+		{
+			"*int8",
+			"bigint",
+			int8(1),
+			&PtrInt8,
+			true,
+		},
+		{
+			"*byte",
+			"bigint",
+			byte(1),
+			&PtrByte,
+			true,
+		},
+		{
+			"*int16",
+			"bigint",
+			int16(1),
+			&PtrInt16,
+			true,
+		},
+		{
+			"*int32",
+			"bigint",
+			int32(1),
+			&PtrInt32,
+			true,
+		},
+		{
+			"*int",
+			"bigint",
+			int(1),
+			&PtrInt,
+			true,
+		},
+		{
+			"*int64",
+			"bigint",
+			int64(1),
+			&PtrInt64,
+			true,
+		},
+		{
+			"*uint8",
+			"bigint",
+			uint8(1),
+			&PtrUint8,
+			true,
+		},
+		{
+			"*uint16",
+			"bigint",
+			uint16(1),
+			&PtrUint16,
+			true,
+		},
+		{
+			"*uint32",
+			"bigint",
+			uint32(1),
+			&PtrUint32,
+			true,
+		},
+		{
+			"*uint",
+			"bigint",
+			uint(1),
+			&PtrUint,
+			true,
+		},
+		{
+			"*uint64",
+			"bigint",
+			uint64(1),
+			&PtrUint64,
+			true,
+		},
+		{
+			"*float32",
+			"decimal",
+			float32(.5),
+			&PtrFloat32,
+			true,
+		},
+		{
+			"*float64",
+			"decimal",
+			float64(.5),
+			&PtrFloat64,
+			true,
+		},
+		{
+			"*bool",
+			"bool",
+			true,
+			&PtrBool,
+			true,
+		},
+		{
+			"*time.Duration",
+			"bigint",
+			3 * time.Second,
+			&PtrDuration,
+			true,
+		},
+		{
+			"*time.Time",
+			"timestamptz",
+			tim,
+			&PtrTime,
+			true,
 		},
 	}
 
@@ -269,6 +424,9 @@ func TestNullable(t *testing.T) {
 
 		s.Nil(db.QueryRow("SELECT testcol FROM foo").Scan(Nullable(c.dst)), c.name)
 		elem = reflect.ValueOf(c.dst).Elem()
+		if c.isPtr {
+			elem = elem.Elem()
+		}
 		s.Equal(c.nonNullInput, elem.Interface(), c.name)
 
 		_, err = db.Exec("DROP TABLE foo")


### PR DESCRIPTION
So, how to do that?

By implementing again all basic types in Nullable, only this time not for `*T` but also for `**T`, which allows you to set a value even if the ptr was initially `nil`.

This fixes the bug @ajnavarro reported yesterday, there's a test now to ensure that.