### PR TITLE
Use multiple GOPATH in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - go get -v -t ./generator/...
 
 script:
-  - make test
+  - GOPATH="$GOPATH:/tmp/dummyGoPath" make test
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
It should reveal the bug #123, and once it is fixed it will ensure no regression happens.