### PR TITLE
Fix import paths using windows path separators (fixes #129)

### DIFF
--- a/generator/processor.go
+++ b/generator/processor.go
@@ -466,7 +466,9 @@ func typeName(typ types.Type) string {
 }
 
 func removeGoPath(path string) string {
-	return strings.Replace(path, goPath+"/src/", "", -1)
+	importPath := filepath.ToSlash(goPath + "/src/")
+	path = filepath.ToSlash(path)
+	return strings.Replace(path, importPath, "", -1)
 }
 
 func isIgnoredField(s *types.Struct, idx int) bool {


### PR DESCRIPTION
Convert back-slashes in import path to slashes so the comparison to the base type succeeds.