### PR TITLE
implement sql migrations

### DIFF
--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -1,0 +1,100 @@
+package generator
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrationGeneratorLoadLock(t *testing.T) {
+	dir, err := ioutil.TempDir("", "kallax-migration-generator")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	g := NewMigrationGenerator("migration", dir)
+	schema, err := g.LoadLock()
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+	require.Len(t, schema.Tables, 0)
+
+	content, err := mkModel(mkTable("foo")).MarshalText()
+	require.NoError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(dir, string(migrationLock)), content, 0755)
+	require.NoError(t, err)
+
+	schema, err = g.LoadLock()
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+	require.Len(t, schema.Tables, 1)
+}
+
+func TestMigrationGeneratorBuild(t *testing.T) {
+	dir, err := ioutil.TempDir("", "kallax-migration-generator")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	g := NewMigrationGenerator("migration", dir)
+	content, err := mkModel(mkTable("foo")).MarshalText()
+	require.NoError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(dir, string(migrationLock)), content, 0755)
+	require.NoError(t, err)
+
+	migration, err := g.Build()
+	require.NoError(t, err)
+	require.NotNil(t, migration)
+}
+
+func TestMigrationGeneratorGenerate(t *testing.T) {
+	old := mkModel(table1)
+	new := mkModel(table1, table2)
+	migration := NewMigration(old, new)
+
+	dir, err := ioutil.TempDir("", "kallax-migration-generator")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	g := NewMigrationGenerator("migration", dir)
+	g.now = func() time.Time {
+		var t time.Time
+		return t
+	}
+
+	require.NoError(t, g.Generate(migration))
+
+	content, err := ioutil.ReadFile(g.migrationFile(migrationUp, g.now()))
+	require.NoError(t, err)
+	require.Equal(t, expectedTable2+"\n\n", string(content))
+
+	content, err = ioutil.ReadFile(g.migrationFile(migrationDown, g.now()))
+	require.NoError(t, err)
+	require.Equal(t, "DROP TABLE table2;\n\n", string(content))
+
+	expected, err := migration.Lock.MarshalText()
+	require.NoError(t, err)
+
+	content, err = ioutil.ReadFile(filepath.Join(dir, string(migrationLock)))
+	require.NoError(t, err)
+	require.Equal(t, string(expected), string(content))
+}
+
+func TestSlugify(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"the fancy slug", "the_fancy_slug"},
+		{"ThE-FaNcYnEss", "the_fancyness"},
+		{"this is: a migration", "this_is_a_migration"},
+		{"add caché", "add_cach"},
+	}
+
+	for _, c := range cases {
+		require.Equal(t, c.expected, slugify(c.input))
+	}
+}

--- a/generator/migration.go
+++ b/generator/migration.go
@@ -15,25 +15,31 @@ type Migration struct {
 	// Down contains all the changes to downgrade to the previous version.
 	Down ChangeSet
 	// Lock contains the locked model schema.
-	Lock *ModelSchema
+	Lock *DBSchema
 }
 
 // NewMigration creates a new migration from the old and the new schema.
-func NewMigration(old, new *ModelSchema) *Migration {
+func NewMigration(old, new *DBSchema) *Migration {
 	var migration = &Migration{}
 	migration.Up = SchemaDiff(old, new)
-	migration.Down = ReverseChangeSet(migration.Up, old)
+	migration.Down = migration.Up.ReverseChangeSet(old)
 	migration.Lock = new
 	return migration
 }
 
-// ModelSchema represents a schema of all the models in the database.
-type ModelSchema struct {
+// DBSchema represents a schema of all the models in the database.
+type DBSchema struct {
 	// Tables are the schema of all the tables.
 	Tables []*TableSchema
 }
 
-func (s *ModelSchema) MarshalText() ([]byte, error) {
+// SchemaFromPackages returns a schema for the given packages models.
+func SchemaFromPackages(pkgs ...*Package) (*DBSchema, error) {
+	t := newPackageTransformer()
+	return t.transform(pkgs...)
+}
+
+func (s *DBSchema) MarshalText() ([]byte, error) {
 	schema := struct {
 		Tables []*TableSchema
 	}{s.Tables}
@@ -41,7 +47,7 @@ func (s *ModelSchema) MarshalText() ([]byte, error) {
 }
 
 // Table finds a table with the given name.
-func (s *ModelSchema) Table(name string) *TableSchema {
+func (s *DBSchema) Table(name string) *TableSchema {
 	for _, t := range s.Tables {
 		if t.Name == name {
 			return t
@@ -62,6 +68,7 @@ func (s *TableSchema) String() string {
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("CREATE TABLE %s (\n", s.Name))
 	for i, c := range s.Columns {
+		buf.WriteRune('\t')
 		buf.WriteString(c.String())
 		if i < len(s.Columns)-1 {
 			buf.WriteString(",\n")
@@ -69,7 +76,7 @@ func (s *TableSchema) String() string {
 			buf.WriteRune('\n')
 		}
 	}
-	buf.WriteString(");\n")
+	buf.WriteString(");\n\n")
 	return buf.String()
 }
 
@@ -81,6 +88,20 @@ func (s *TableSchema) Column(name string) *ColumnSchema {
 		}
 	}
 	return nil
+}
+
+func (s *TableSchema) Equals(s2 *TableSchema) bool {
+	if s.Name != s2.Name || len(s.Columns) != len(s2.Columns) {
+		return false
+	}
+
+	for i, c := range s.Columns {
+		if !c.Equals(s2.Columns[i]) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // ColumnSchema represents the schema of a column.
@@ -96,6 +117,14 @@ type ColumnSchema struct {
 	Reference *Reference
 	// NotNull reports whether the column is not nullable.
 	NotNull bool
+}
+
+func (s *ColumnSchema) Equals(s2 *ColumnSchema) bool {
+	return s.Name == s2.Name &&
+		s.Type == s2.Type &&
+		s.PrimaryKey == s2.PrimaryKey &&
+		s.NotNull == s2.NotNull &&
+		s.Reference.Equals(s2.Reference)
 }
 
 func (s *ColumnSchema) String() string {
@@ -139,8 +168,8 @@ const (
 	UUIDColumn        ColumnType = "uuid"
 )
 
-func NumericColumn(precision, scale int) ColumnType {
-	return ColumnType(fmt.Sprintf("numeric(%d, %d)", precision, scale))
+func NumericColumn(precision int) ColumnType {
+	return ColumnType(fmt.Sprintf("numeric(%d)", precision))
 }
 
 func DecimalColumn(precision, scale int) ColumnType {
@@ -163,6 +192,17 @@ type Reference struct {
 	Column string
 }
 
+func (r *Reference) Equals(r2 *Reference) bool {
+	if r == nil && r2 == nil {
+		return true
+	} else if r == nil || r2 == nil {
+		return false
+	}
+
+	return r.Table == r2.Table &&
+		r.Column == r2.Column
+}
+
 func (r *Reference) String() string {
 	return fmt.Sprintf("%s(%s)", r.Table, r.Column)
 }
@@ -178,13 +218,39 @@ func (cs ChangeSet) MarshalText() ([]byte, error) {
 			return nil, err
 		}
 		buf.Write(bytes)
+		buf.WriteRune('\n')
 	}
 	return buf.Bytes(), nil
+}
+
+func (cs ChangeSet) String() string {
+	var buf bytes.Buffer
+	for _, c := range cs {
+		buf.WriteString(fmt.Sprintf("- %s", c))
+	}
+	return buf.String()
+}
+
+// Reverse returns the change that will revert the current change set.
+func (cs ChangeSet) Reverse(old *DBSchema) Change {
+	var result = make(ChangeSet, len(cs))
+	for i, c := range cs {
+		result[i] = c.Reverse(old)
+	}
+	return result
+}
+
+// ReverseChangeSet returns the reverse change set of the current one.
+func (cs ChangeSet) ReverseChangeSet(old *DBSchema) ChangeSet {
+	return cs.Reverse(old).(ChangeSet)
 }
 
 // Change represents a change to be made in a migration.
 type Change interface {
 	encoding.TextMarshaler
+	fmt.Stringer
+	// Reverse returns the change that will revert the current change.
+	Reverse(old *DBSchema) Change
 }
 
 // CreateTable is a change that will add a new table.
@@ -192,8 +258,20 @@ type CreateTable struct {
 	*TableSchema
 }
 
+func (c *CreateTable) Reverse(old *DBSchema) Change {
+	return &DropTable{Name: c.Name}
+}
+
 func (c *CreateTable) MarshalText() ([]byte, error) {
 	return []byte(c.TableSchema.String()), nil
+}
+
+func (c *CreateTable) String() string {
+	var cols = make([]string, len(c.Columns))
+	for i, c := range c.Columns {
+		cols[i] = c.Name
+	}
+	return fmt.Sprintf("A new table %q has been added with the following columns: %s.", c.Name, strings.Join(cols, ", "))
 }
 
 // DropTable is a change that will drop a table.
@@ -202,8 +280,16 @@ type DropTable struct {
 	Name string
 }
 
+func (c *DropTable) Reverse(old *DBSchema) Change {
+	return &CreateTable{old.Table(c.Name)}
+}
+
 func (c *DropTable) MarshalText() ([]byte, error) {
 	return []byte(fmt.Sprintf("DROP TABLE %s;\n", c.Name)), nil
+}
+
+func (c *DropTable) String() string {
+	return fmt.Sprintf("Table %q has been deleted, and it will be dropped.", c.Name)
 }
 
 // AddColumn is a change that will add a column.
@@ -214,12 +300,19 @@ type AddColumn struct {
 	Table string
 }
 
+func (c *AddColumn) Reverse(old *DBSchema) Change {
+	return &DropColumn{
+		Table: c.Table,
+		Name:  c.Column.Name,
+	}
+}
+
+func (c *AddColumn) String() string {
+	return fmt.Sprintf("A new column %q of type %q has been added to table %q.", c.Column.Name, c.Column.Type, c.Table)
+}
+
 func (c *AddColumn) MarshalText() ([]byte, error) {
-	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("ALTER TABLE %s ADD COLUMN ", c.Table))
-	buf.WriteString(c.Column.String())
-	buf.WriteString(";\n")
-	return buf.Bytes(), nil
+	return []byte(fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s;\n", c.Table, c.Column)), nil
 }
 
 // DropColumn is a change that will drop a column.
@@ -228,6 +321,17 @@ type DropColumn struct {
 	Name string
 	// Table name.
 	Table string
+}
+
+func (c *DropColumn) Reverse(old *DBSchema) Change {
+	return &AddColumn{
+		Table:  c.Table,
+		Column: old.Table(c.Table).Column(c.Name),
+	}
+}
+
+func (c *DropColumn) String() string {
+	return fmt.Sprintf("The column %q of table %q has been removed and it will be dropped.", c.Name, c.Table)
 }
 
 func (c *DropColumn) MarshalText() ([]byte, error) {
@@ -240,12 +344,20 @@ type ManualChange struct {
 	Msg string
 }
 
+func (c *ManualChange) Reverse(old *DBSchema) Change {
+	return c
+}
+
+func (c *ManualChange) String() string {
+	return fmt.Sprintf("A manual change is required: %s.", c.Msg)
+}
+
 func (c *ManualChange) MarshalText() ([]byte, error) {
 	return []byte(fmt.Sprintf("+++ THIS REQUIRES MANUAL MIGRATION: %s +++\n", c.Msg)), nil
 }
 
 // SchemaDiff generates a change set with the diff between two schemas.
-func SchemaDiff(old, new *ModelSchema) ChangeSet {
+func SchemaDiff(old, new *DBSchema) ChangeSet {
 	var cs ChangeSet
 	for _, oldTable := range old.Tables {
 		if t := new.Table(oldTable.Name); t == nil {
@@ -329,42 +441,261 @@ func referenceChanged(old, new *ColumnSchema) bool {
 			old.Reference.Table != new.Reference.Table)
 }
 
-// ReverseChangeSet returns a new change set with the inverses of the given
-// change set.
-func ReverseChangeSet(cs ChangeSet, old *ModelSchema) ChangeSet {
-	var result = make(ChangeSet, len(cs))
-	for i, c := range cs {
-		result[i] = reverseChange(c, old)
-	}
-	return result
+type packageTransformer struct {
+	// pkg is the current package being transformed.
+	pkg *Package
+	// schema is the final schema being built.
+	schema *DBSchema
+
+	tables map[string]*TableSchema
+	// tableIndex is a map from a Go type to a table name
+	tableIndex map[string]string
+	// pkIndex is a map from a table name to its primary key
+	pkIndex map[string]*Field
+	// inverses keeps all inverses indexed by type name
+	// so they can be added later.
+	inverses map[string][]*ColumnSchema
 }
 
-// reverseChange generates the inverse of a change.
-func reverseChange(c Change, old *ModelSchema) Change {
-	switch c := c.(type) {
-	case *CreateTable:
-		return &DropTable{Name: c.Name}
+func newPackageTransformer() *packageTransformer {
+	return &packageTransformer{
+		schema:     new(DBSchema),
+		tables:     make(map[string]*TableSchema),
+		tableIndex: make(map[string]string),
+		pkIndex:    make(map[string]*Field),
+		inverses:   make(map[string][]*ColumnSchema),
+	}
+}
 
-	case *DropTable:
-		return &CreateTable{old.Table(c.Name)}
-
-	case *AddColumn:
-		return &DropColumn{
-			Table: c.Table,
-			Name:  c.Column.Name,
-		}
-
-	case *DropColumn:
-		return &AddColumn{
-			Table:  c.Table,
-			Column: old.Table(c.Table).Column(c.Name),
-		}
-
-	case *ManualChange:
-		return &ManualChange{
-			Msg: c.Msg,
+func (t *packageTransformer) transform(pkgs ...*Package) (*DBSchema, error) {
+	for _, pkg := range pkgs {
+		for _, m := range pkg.Models {
+			t.tableIndex[m.Node.String()] = m.Table
+			t.pkIndex[m.Table] = m.ID
 		}
 	}
 
-	panic("unreachable")
+	for _, pkg := range pkgs {
+		t.pkg = pkg
+		if err := t.transformPkg(pkg); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := t.applyInverses(); err != nil {
+		return nil, err
+	}
+
+	return t.schema, nil
+}
+
+func (t *packageTransformer) applyInverses() error {
+	for typ, inverses := range t.inverses {
+		table, ok := t.tableIndex[typ]
+		if !ok {
+			return fmt.Errorf("kallax: unable to find a table for model %s. Is the model package on the input for this command?", typ)
+		}
+
+		schema := t.tables[table]
+		for _, inv := range inverses {
+			if col := schema.Column(inv.Name); col != nil {
+				if !col.Equals(inv) {
+					return fmt.Errorf("kallax: there is an inverse definition conflicting with the column definition of column %s in the table %s. Please, make sure both definitions match.", inv.Name, table)
+				}
+			} else {
+				schema.Columns = append(schema.Columns, inv)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (t *packageTransformer) transformPkg(pkg *Package) error {
+	for _, m := range pkg.Models {
+		table, err := t.transformModel(m)
+		if err != nil {
+			return err
+		}
+
+		if prevTable, ok := t.tables[m.Table]; ok && !prevTable.Equals(table) {
+			return fmt.Errorf("kallax: found more than one model for table %s", m.Table)
+		}
+
+		t.schema.Tables = append(t.schema.Tables, table)
+		t.tables[table.Name] = table
+	}
+	return nil
+}
+
+func (t *packageTransformer) transformModel(m *Model) (*TableSchema, error) {
+	schema := &TableSchema{Name: m.Table}
+	var columns = make(map[string]*ColumnSchema)
+	var err error
+	schema.Columns, err = t.transformFields(m.Fields, columns)
+	if err != nil {
+		return nil, err
+	}
+
+	return schema, nil
+}
+
+func (t *packageTransformer) transformFields(fields []*Field, columns map[string]*ColumnSchema) ([]*ColumnSchema, error) {
+	var result []*ColumnSchema
+
+	for _, f := range fields {
+		if f.IsEmbedded {
+			cols, err := t.transformFields(f.Fields, columns)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, cols...)
+		} else {
+			column, err := t.transformField(f)
+			if err != nil {
+				return nil, err
+			}
+
+			if f.Kind == Relationship && f.IsInverse() {
+				typ := removeTypePrefix(f.Type)
+				t.inverses[typ] = append(t.inverses[typ], column)
+			} else if col, ok := columns[f.ColumnName()]; ok {
+				if !col.Equals(column) {
+					return nil, fmt.Errorf("kallax: there are two conflicting definitions for column %s on table %s: \n- %s\n- %s", col.Name, f.Model.Table, col, column)
+				}
+				// if it's the same column we can skip it
+			} else {
+				result = append(result, column)
+				columns[column.Name] = column
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func (t *packageTransformer) transformField(f *Field) (*ColumnSchema, error) {
+	typ, err := t.transformType(f, f.IsPrimaryKey())
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := t.transformRef(f)
+	if err != nil {
+		return nil, err
+	}
+
+	name := f.ColumnName()
+	if f.Kind == Relationship {
+		name = f.ForeignKey()
+	}
+
+	return &ColumnSchema{
+		Name:       name,
+		PrimaryKey: f.IsPrimaryKey(),
+		NotNull:    false,
+		Type:       typ,
+		Reference:  ref,
+	}, nil
+}
+
+func (t *packageTransformer) transformType(f *Field, pk bool) (ColumnType, error) {
+	if typ := f.SQLType(); typ != "" {
+		return ColumnType(typ), nil
+	}
+
+	if f.IsJSON {
+		return JSONBColumn, nil
+	}
+
+	if f.Kind == Array || f.Kind == Slice {
+		return ArrayColumn(typeMappings[removeTypePrefix(f.Type)]), nil
+	}
+
+	if pk {
+		if !isValidIdentifier(f) {
+			return ColumnType(""), fmt.Errorf("kallax: type %s is not a valid type for a primary key. On field %s of model %s.", f.Type, f.Name, f.Model.Name)
+		}
+
+		return idTypeMappings[identifierType(f)], nil
+	}
+
+	if f.Kind == Basic {
+		typ, ok := typeMappings[f.Type]
+		if !ok {
+			return ColumnType(""), fmt.Errorf("kallax: type %s can not be converted to a SQL type. On field %s of model %s. Consider using the struct tag `sqltype` to set a custom type for this column.", f.Type, f.Name, f.Model.Name)
+		}
+		return typ, nil
+	}
+
+	if f.Kind == Relationship && !f.IsInverse() {
+		typ := removeTypePrefix(f.Type)
+		table, ok := t.tableIndex[typ]
+		if !ok {
+			return ColumnType(""), fmt.Errorf("kallax: unable to find table for type %s in field %s of model %s. Is the model type part of the generation input?", typ, f.Name, f.Model.Name)
+		}
+
+		return t.transformType(t.pkIndex[table], false)
+	}
+
+	if f.Kind == Relationship {
+		return t.transformType(f.Model.ID, false)
+	}
+
+	if f.Kind == Interface {
+		typ := removeTypePrefix(typeName(f.Node.Type()))
+		if typ, ok := typeMappings[typ]; ok {
+			return typ, nil
+		}
+	}
+
+	return ColumnType(""), fmt.Errorf("kallax: cannot find a suitable type (%s) for field %s of model %s. Consider using the struct tag `sqltype` to set a custom type for this column.", f.Type, f.Name, f.Model.Name)
+}
+
+func (t *packageTransformer) transformRef(f *Field) (*Reference, error) {
+	if f.Kind == Relationship && !f.IsInverse() {
+		typ := removeTypePrefix(f.Type)
+		table, ok := t.tableIndex[typ]
+		if !ok {
+			return nil, fmt.Errorf("kallax: unable to find table for type %s in field %s of model %s. Is the model type part of the generation input?", typ, f.Name, f.Model.Name)
+		}
+
+		return &Reference{Table: table, Column: t.pkIndex[table].ColumnName()}, nil
+	} else if f.Kind == Relationship {
+		return &Reference{Table: f.Model.Table, Column: f.Model.ID.ColumnName()}, nil
+	}
+
+	return nil, nil
+}
+
+var typeMappings = map[string]ColumnType{
+	"gopkg.in/src-d/go-kallax.v1.ULID":      UUIDColumn,
+	"gopkg.in/src-d/go-kallax.v1.UUID":      UUIDColumn,
+	"gopkg.in/src-d/go-kallax.v1.NumericID": BigIntColumn,
+	"github.com/satori/go.uuid.UUID":        UUIDColumn,
+	"string":        TextColumn,
+	"rune":          ColumnType("char(1)"),
+	"uint8":         SmallIntColumn,
+	"int8":          SmallIntColumn,
+	"byte":          SmallIntColumn,
+	"uint16":        IntegerColumn,
+	"int16":         SmallIntColumn,
+	"uint32":        BigIntColumn,
+	"int32":         IntegerColumn,
+	"uint":          NumericColumn(20),
+	"int":           BigIntColumn,
+	"int64":         BigIntColumn,
+	"uint64":        NumericColumn(20),
+	"float32":       RealColumn,
+	"float64":       DoubleColumn,
+	"bool":          BooleanColumn,
+	"url.URL":       TextColumn,
+	"time.Time":     TimestamptzColumn,
+	"time.Duration": BigIntColumn,
+}
+
+var idTypeMappings = map[string]ColumnType{
+	"kallax.ULID":      UUIDColumn,
+	"kallax.UUID":      UUIDColumn,
+	"kallax.NumericID": SerialColumn,
 }

--- a/generator/migration.go
+++ b/generator/migration.go
@@ -1,0 +1,370 @@
+package generator
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Migration contains all the data to represent a schema migration.
+type Migration struct {
+	// Up contains the changes to update from the previous version to the current one.
+	Up ChangeSet
+	// Down contains all the changes to downgrade to the previous version.
+	Down ChangeSet
+	// Lock contains the locked model schema.
+	Lock *ModelSchema
+}
+
+// NewMigration creates a new migration from the old and the new schema.
+func NewMigration(old, new *ModelSchema) *Migration {
+	var migration = &Migration{}
+	migration.Up = SchemaDiff(old, new)
+	migration.Down = ReverseChangeSet(migration.Up, old)
+	migration.Lock = new
+	return migration
+}
+
+// ModelSchema represents a schema of all the models in the database.
+type ModelSchema struct {
+	// Tables are the schema of all the tables.
+	Tables []*TableSchema
+}
+
+func (s *ModelSchema) MarshalText() ([]byte, error) {
+	schema := struct {
+		Tables []*TableSchema
+	}{s.Tables}
+	return json.MarshalIndent(schema, "", "  ")
+}
+
+// Table finds a table with the given name.
+func (s *ModelSchema) Table(name string) *TableSchema {
+	for _, t := range s.Tables {
+		if t.Name == name {
+			return t
+		}
+	}
+	return nil
+}
+
+// TableSchema represents the SQL schema of a table.
+type TableSchema struct {
+	// Name is the table name.
+	Name string
+	// Columns are the schemas of the columns in the table.
+	Columns []*ColumnSchema
+}
+
+func (s *TableSchema) String() string {
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("CREATE TABLE %s (\n", s.Name))
+	for i, c := range s.Columns {
+		buf.WriteString(c.String())
+		if i < len(s.Columns)-1 {
+			buf.WriteString(",\n")
+		} else {
+			buf.WriteRune('\n')
+		}
+	}
+	buf.WriteString(");\n")
+	return buf.String()
+}
+
+// Columns returns the schema of the column with the given name.
+func (s *TableSchema) Column(name string) *ColumnSchema {
+	for _, c := range s.Columns {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// ColumnSchema represents the schema of a column.
+type ColumnSchema struct {
+	// Name of the column.
+	Name string
+	// Type of the column.
+	Type ColumnType
+	// PrimaryKey reports whether the column is a primary key.
+	PrimaryKey bool
+	// Reference is an optional reference to another table column.
+	// If it's not nil, it means this column has a foreign key.
+	Reference *Reference
+	// NotNull reports whether the column is not nullable.
+	NotNull bool
+}
+
+func (s *ColumnSchema) String() string {
+	var buf bytes.Buffer
+	buf.WriteString(s.Name)
+	buf.WriteRune(' ')
+	buf.WriteString(string(s.Type))
+
+	if s.NotNull {
+		buf.WriteString(" NOT NULL")
+	}
+
+	if s.PrimaryKey {
+		buf.WriteString(" PRIMARY KEY")
+	}
+
+	if s.Reference != nil {
+		buf.WriteString(" REFERENCES ")
+		buf.WriteString(s.Reference.String())
+	}
+
+	return buf.String()
+}
+
+// ColumnType represents the SQL column type.
+type ColumnType string
+
+const (
+	SmallIntColumn    ColumnType = "smallint"
+	IntegerColumn     ColumnType = "integer"
+	BigIntColumn      ColumnType = "bigint"
+	RealColumn        ColumnType = "real"
+	DoubleColumn      ColumnType = "double"
+	SmallSerialColumn ColumnType = "smallserial"
+	SerialColumn      ColumnType = "serial"
+	BigSerialColumn   ColumnType = "bigserial"
+	TimestamptzColumn ColumnType = "timestamptz"
+	TextColumn        ColumnType = "text"
+	JSONBColumn       ColumnType = "jsonb"
+	BooleanColumn     ColumnType = "boolean"
+	UUIDColumn        ColumnType = "uuid"
+)
+
+func NumericColumn(precision, scale int) ColumnType {
+	return ColumnType(fmt.Sprintf("numeric(%d, %d)", precision, scale))
+}
+
+func DecimalColumn(precision, scale int) ColumnType {
+	return ColumnType(fmt.Sprintf("decimal(%d, %d)", precision, scale))
+}
+
+func ArrayColumn(typ ColumnType) ColumnType {
+	// only allow arrays, not matrixes
+	if strings.HasSuffix(string(typ), "[]") {
+		return typ
+	}
+	return typ + "[]"
+}
+
+// Reference represents a reference to another table column.
+type Reference struct {
+	// Table is the referenced table.
+	Table string
+	// Column is the referenced column.
+	Column string
+}
+
+func (r *Reference) String() string {
+	return fmt.Sprintf("%s(%s)", r.Table, r.Column)
+}
+
+// ChangeSet is a set of changes to be made in a migration.
+type ChangeSet []Change
+
+func (cs ChangeSet) MarshalText() ([]byte, error) {
+	var buf bytes.Buffer
+	for _, c := range cs {
+		bytes, err := c.MarshalText()
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(bytes)
+	}
+	return buf.Bytes(), nil
+}
+
+// Change represents a change to be made in a migration.
+type Change interface {
+	encoding.TextMarshaler
+}
+
+// CreateTable is a change that will add a new table.
+type CreateTable struct {
+	*TableSchema
+}
+
+func (c *CreateTable) MarshalText() ([]byte, error) {
+	return []byte(c.TableSchema.String()), nil
+}
+
+// DropTable is a change that will drop a table.
+type DropTable struct {
+	// Name is the name of the table to drop.
+	Name string
+}
+
+func (c *DropTable) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("DROP TABLE %s;\n", c.Name)), nil
+}
+
+// AddColumn is a change that will add a column.
+type AddColumn struct {
+	// Column schema.
+	Column *ColumnSchema
+	// Table to add the column to.
+	Table string
+}
+
+func (c *AddColumn) MarshalText() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("ALTER TABLE %s ADD COLUMN ", c.Table))
+	buf.WriteString(c.Column.String())
+	buf.WriteString(";\n")
+	return buf.Bytes(), nil
+}
+
+// DropColumn is a change that will drop a column.
+type DropColumn struct {
+	// Name of the column.
+	Name string
+	// Table name.
+	Table string
+}
+
+func (c *DropColumn) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s;\n", c.Table, c.Name)), nil
+}
+
+// ManualChange is a change that cannot be made automatically and requires
+// the user to write a proper migration.
+type ManualChange struct {
+	Msg string
+}
+
+func (c *ManualChange) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("+++ THIS REQUIRES MANUAL MIGRATION: %s +++\n", c.Msg)), nil
+}
+
+// SchemaDiff generates a change set with the diff between two schemas.
+func SchemaDiff(old, new *ModelSchema) ChangeSet {
+	var cs ChangeSet
+	for _, oldTable := range old.Tables {
+		if t := new.Table(oldTable.Name); t == nil {
+			cs = append(cs, &DropTable{Name: oldTable.Name})
+		} else {
+			cs = append(cs, TableSchemaDiff(oldTable, t)...)
+		}
+	}
+
+	for _, newTable := range new.Tables {
+		if t := old.Table(newTable.Name); t == nil {
+			cs = append(cs, &CreateTable{newTable})
+		}
+	}
+
+	return cs
+}
+
+// TableSchemaDiff generates a change set with the diff between two table
+// schemas.
+func TableSchemaDiff(old, new *TableSchema) ChangeSet {
+	var cs ChangeSet
+	for _, oldCol := range old.Columns {
+		if c := new.Column(oldCol.Name); c == nil {
+			cs = append(cs, &DropColumn{
+				Table: old.Name,
+				Name:  oldCol.Name,
+			})
+		} else {
+			cs = append(cs, ColumnSchemaDiff(old.Name, oldCol, c)...)
+		}
+	}
+
+	for _, newCol := range new.Columns {
+		if c := old.Column(newCol.Name); c == nil {
+			cs = append(cs, &AddColumn{
+				Table:  new.Name,
+				Column: newCol,
+			})
+		}
+	}
+	return cs
+}
+
+// ColumnSchemaDiff generates the change set with the diff between two column
+// schemas.
+func ColumnSchemaDiff(table string, old, new *ColumnSchema) ChangeSet {
+	var cs ChangeSet
+	if old.Type != new.Type {
+		cs = append(cs, &ManualChange{
+			fmt.Sprintf("don't know how to generate migration for a change of type in %s(%s)", table, new.Name),
+		})
+	}
+
+	if old.PrimaryKey != new.PrimaryKey {
+		cs = append(cs, &ManualChange{
+			fmt.Sprintf("don't know how to generate migration for a change of primary key in %s(%s)", table, new.Name),
+		})
+	}
+
+	if old.NotNull != new.NotNull {
+		cs = append(cs, &ManualChange{
+			fmt.Sprintf("don't know how to generate migration for a change of null/not null in %s(%s)", table, new.Name),
+		})
+	}
+
+	if referenceChanged(old, new) {
+		cs = append(cs, &ManualChange{
+			fmt.Sprintf("don't know how to generate migration for a change of foreign key in %s(%s)", table, new.Name),
+		})
+	}
+
+	return cs
+}
+
+func referenceChanged(old, new *ColumnSchema) bool {
+	return old.Reference != new.Reference &&
+		(old.Reference == nil ||
+			new.Reference == nil ||
+			old.Reference.Column != new.Reference.Column ||
+			old.Reference.Table != new.Reference.Table)
+}
+
+// ReverseChangeSet returns a new change set with the inverses of the given
+// change set.
+func ReverseChangeSet(cs ChangeSet, old *ModelSchema) ChangeSet {
+	var result = make(ChangeSet, len(cs))
+	for i, c := range cs {
+		result[i] = reverseChange(c, old)
+	}
+	return result
+}
+
+// reverseChange generates the inverse of a change.
+func reverseChange(c Change, old *ModelSchema) Change {
+	switch c := c.(type) {
+	case *CreateTable:
+		return &DropTable{Name: c.Name}
+
+	case *DropTable:
+		return &CreateTable{old.Table(c.Name)}
+
+	case *AddColumn:
+		return &DropColumn{
+			Table: c.Table,
+			Name:  c.Column.Name,
+		}
+
+	case *DropColumn:
+		return &AddColumn{
+			Table:  c.Table,
+			Column: old.Table(c.Table).Column(c.Name),
+		}
+
+	case *ManualChange:
+		return &ManualChange{
+			Msg: c.Msg,
+		}
+	}
+
+	panic("unreachable")
+}

--- a/generator/migration_test.go
+++ b/generator/migration_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 func TestNewMigration(t *testing.T) {
@@ -28,25 +29,24 @@ var table1 = mkTable(
 var table2 = mkTable(
 	"table2",
 	mkCol("table_id", SerialColumn, false, true, mkRef("table", "id")),
-	mkCol("num", NumericColumn(1, 2), false, false, nil),
+	mkCol("num", NumericColumn(20), false, false, nil),
 )
 
 const expectedTable = `CREATE TABLE table (
-id serial NOT NULL PRIMARY KEY,
-num decimal(1, 2)
+	id serial NOT NULL PRIMARY KEY,
+	num decimal(1, 2)
 );
 `
 
 const expectedTable2 = `CREATE TABLE table2 (
-table_id serial NOT NULL REFERENCES table(id),
-num numeric(1, 2)
+	table_id serial NOT NULL REFERENCES table(id),
+	num numeric(20)
 );
 `
 
 func TestTableSchema(t *testing.T) {
-
-	require.Equal(t, expectedTable, table1.String())
-	require.Equal(t, expectedTable2, table2.String())
+	require.Equal(t, expectedTable+"\n", table1.String())
+	require.Equal(t, expectedTable2+"\n", table2.String())
 }
 
 func TestArrayColumn(t *testing.T) {
@@ -61,7 +61,7 @@ func TestChangeSet(t *testing.T) {
 			&DropTable{"foo"},
 			&DropColumn{"col", "table"},
 		},
-		"DROP TABLE foo;\nALTER TABLE table DROP COLUMN col;\n",
+		"DROP TABLE foo;\n\nALTER TABLE table DROP COLUMN col;\n\n",
 	)
 }
 
@@ -74,9 +74,10 @@ func TestCreateTable(t *testing.T) {
 			mkCol("bar", SerialColumn, false, false, nil),
 		)},
 		`CREATE TABLE table (
-foo smallint,
-bar serial
+	foo smallint,
+	bar serial
 );
+
 `)
 }
 
@@ -283,12 +284,246 @@ func TestReverseChange(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		require.Equal(c.expected, reverseChange(c.original, old), "%T", c.original)
+		require.Equal(c.expected, c.original.Reverse(old), "%T", c.original)
 	}
 }
 
-func mkModel(tables ...*TableSchema) *ModelSchema {
-	return &ModelSchema{tables}
+func TestTableSchemaEquals(t *testing.T) {
+	cases := []struct {
+		name     string
+		schema   *TableSchema
+		expected bool
+	}{
+		{
+			"different name",
+			mkTable("bar"),
+			false,
+		},
+		{
+			"different number of columns",
+			mkTable(
+				"foo",
+				mkCol("col1", IntegerColumn, false, false, nil),
+				mkCol("col2", IntegerColumn, false, false, nil),
+				mkCol("col3", IntegerColumn, false, false, nil),
+			),
+			false,
+		},
+		{
+			"different column",
+			mkTable(
+				"foo",
+				mkCol("col1", IntegerColumn, false, false, nil),
+				mkCol("col4", IntegerColumn, false, false, nil),
+			),
+			false,
+		},
+		{
+			"equal",
+			mkTable(
+				"foo",
+				mkCol("col1", IntegerColumn, false, false, nil),
+				mkCol("col2", IntegerColumn, false, false, nil),
+			),
+			true,
+		},
+	}
+
+	schema := mkTable(
+		"foo",
+		mkCol("col1", IntegerColumn, false, false, nil),
+		mkCol("col2", IntegerColumn, false, false, nil),
+	)
+
+	for _, c := range cases {
+		require.Equal(t, c.expected, schema.Equals(c.schema), c.name)
+	}
+}
+
+func TestColumnSchemaEquals(t *testing.T) {
+	cases := []struct {
+		name     string
+		a, b     *ColumnSchema
+		expected bool
+	}{
+		{
+			"different name",
+			mkCol("foo", TextColumn, false, false, nil),
+			mkCol("bar", TextColumn, false, false, nil),
+			false,
+		},
+		{
+			"different pk",
+			mkCol("id", SerialColumn, true, false, nil),
+			mkCol("id", SerialColumn, false, false, nil),
+			false,
+		},
+		{
+			"different notnull",
+			mkCol("foo", TextColumn, false, true, nil),
+			mkCol("foo", TextColumn, false, false, nil),
+			false,
+		},
+		{
+			"one of the references is nil",
+			mkCol("foo", TextColumn, false, false, nil),
+			mkCol("foo", TextColumn, false, false, mkRef("a", "b")),
+			false,
+		},
+		{
+			"reference table does not match",
+			mkCol("foo", TextColumn, false, false, mkRef("a", "b")),
+			mkCol("foo", TextColumn, false, false, mkRef("b", "b")),
+			false,
+		},
+		{
+			"reference column does not match",
+			mkCol("foo", TextColumn, false, false, mkRef("a", "b")),
+			mkCol("foo", TextColumn, false, false, mkRef("a", "a")),
+			false,
+		},
+		{
+			"equal with reference",
+			mkCol("foo", TextColumn, false, false, mkRef("a", "b")),
+			mkCol("foo", TextColumn, false, false, mkRef("a", "b")),
+			true,
+		},
+		{
+			"equal without reference",
+			mkCol("foo", TextColumn, false, false, nil),
+			mkCol("foo", TextColumn, false, false, nil),
+			true,
+		},
+	}
+
+	for _, c := range cases {
+		require.Equal(t, c.expected, c.a.Equals(c.b), c.name)
+	}
+}
+
+type PackageTransformerSuite struct {
+	suite.Suite
+	t   *packageTransformer
+	pkg *Package
+}
+
+const packageTransformerSourceFixture = `
+package foo
+
+import (
+	"gopkg.in/src-d/go-kallax.v1"
+	"net/url"
+)
+
+type User struct {
+	kallax.Model ` + "`table:\"users\"`" + `
+	ID kallax.ULID ` + "`pk:\"\"`" + `
+	Username string
+	// array field
+	Emails []string
+	// user_id should not be added twice on profile,
+	// even though it is defined as an inverse here
+	Profile *Profile ` + "`fk:\"user_id,inverse\"`" + `
+}
+
+type Profile struct {
+	kallax.Model ` + "`table:\"profiles\"`" + `
+	ID int64 ` + "`pk:\"autoincr\"`" + `
+	Color string ` + "`sqltype:\"char(6)\"`" + `
+	Background url.URL
+	User *User ` + "`fk:\"user_id\"`" + `
+	Spouse *kallax.ULID
+	// an inverse without reference in the other model
+	// should be added anyway
+	// should be added as bigint, as it is not a pk
+	Metadata *ProfileMetadata ` + "`fk:\"profile_id,inverse\"`" + `
+}
+
+type ProfileMetadata struct {
+	kallax.Model ` + "`table:\"metadata\"`" + `	
+	// it's an pk, should be serial
+	ID int64 ` + "`pk:\"autoincr\"`" + `
+	// a json field
+	Metadata map[string]interface{}
+}
+`
+
+func (s *PackageTransformerSuite) SetupTest() {
+	s.t = newPackageTransformer()
+	var err error
+	s.pkg, err = processFixture(packageTransformerSourceFixture)
+	s.Require().NoError(err)
+}
+
+func (s *PackageTransformerSuite) TestTransform() {
+	require := s.Require()
+	schema, err := s.t.transform(s.pkg)
+	require.NoError(err)
+	require.NotNil(schema)
+
+	expected := mkModel(
+		mkTable(
+			"profiles",
+			mkCol("id", SerialColumn, true, false, nil),
+			mkCol("color", ColumnType("char(6)"), false, false, nil),
+			mkCol("background", TextColumn, false, false, nil),
+			mkCol("user_id", UUIDColumn, false, false, mkRef("users", "id")),
+			mkCol("spouse", UUIDColumn, false, false, nil),
+		),
+		mkTable(
+			"metadata",
+			mkCol("id", SerialColumn, true, false, nil),
+			mkCol("metadata", JSONBColumn, false, false, nil),
+			mkCol("profile_id", BigIntColumn, false, false, mkRef("profiles", "id")),
+		),
+		mkTable(
+			"users",
+			mkCol("id", UUIDColumn, true, false, nil),
+			mkCol("username", TextColumn, false, false, nil),
+			mkCol("emails", ArrayColumn(TextColumn), false, false, nil),
+		),
+	)
+
+	require.Equal(expected, schema)
+}
+
+func (s *PackageTransformerSuite) TestApplyInverses_TableNotFound() {
+	s.t.inverses["foo"] = []*ColumnSchema{
+		mkCol("foo", TextColumn, false, false, nil),
+	}
+
+	s.Error(s.t.applyInverses())
+}
+
+func (s *PackageTransformerSuite) TestApplyInverses_ConfictingCol() {
+	s.t.inverses["foo"] = []*ColumnSchema{
+		mkCol("foo", TextColumn, false, false, nil),
+	}
+	s.t.tableIndex["foo"] = "foo"
+	s.t.tables["foo"] = mkTable(
+		"foo",
+		mkCol("bar", TextColumn, false, false, nil),
+		mkCol("foo", IntegerColumn, false, false, nil),
+	)
+
+	s.Error(s.t.applyInverses())
+}
+
+func (s *PackageTransformerSuite) TestTransform_RepeatedTable() {
+	m := *s.pkg.Models[len(s.pkg.Models)-1]
+	m.Fields = nil
+	s.pkg.Models = append(s.pkg.Models, &m)
+
+	_, err := s.t.transform(s.pkg)
+	s.Error(err)
+}
+
+func TestPackageTransformer(t *testing.T) {
+	suite.Run(t, new(PackageTransformerSuite))
+}
+
+func mkModel(tables ...*TableSchema) *DBSchema {
+	return &DBSchema{tables}
 }
 
 func mkTable(name string, columns ...*ColumnSchema) *TableSchema {

--- a/generator/migration_test.go
+++ b/generator/migration_test.go
@@ -1,0 +1,304 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMigration(t *testing.T) {
+	old := mkModel(table1)
+	new := mkModel(table1, table2)
+	migration := NewMigration(old, new)
+
+	expectedUp := ChangeSet{&CreateTable{table2}}
+	expectedDown := ChangeSet{&DropTable{"table2"}}
+
+	require.Equal(t, expectedUp, migration.Up)
+	require.Equal(t, expectedDown, migration.Down)
+	require.Equal(t, migration.Lock, new)
+}
+
+var table1 = mkTable(
+	"table",
+	mkCol("id", SerialColumn, true, true, nil),
+	mkCol("num", DecimalColumn(1, 2), false, false, nil),
+)
+
+var table2 = mkTable(
+	"table2",
+	mkCol("table_id", SerialColumn, false, true, mkRef("table", "id")),
+	mkCol("num", NumericColumn(1, 2), false, false, nil),
+)
+
+const expectedTable = `CREATE TABLE table (
+id serial NOT NULL PRIMARY KEY,
+num decimal(1, 2)
+);
+`
+
+const expectedTable2 = `CREATE TABLE table2 (
+table_id serial NOT NULL REFERENCES table(id),
+num numeric(1, 2)
+);
+`
+
+func TestTableSchema(t *testing.T) {
+
+	require.Equal(t, expectedTable, table1.String())
+	require.Equal(t, expectedTable2, table2.String())
+}
+
+func TestArrayColumn(t *testing.T) {
+	require.Equal(t, ColumnType("text[]"), ArrayColumn(TextColumn))
+	require.Equal(t, ColumnType("text[]"), ArrayColumn(ArrayColumn(TextColumn)))
+}
+
+func TestChangeSet(t *testing.T) {
+	assertChange(
+		t,
+		ChangeSet{
+			&DropTable{"foo"},
+			&DropColumn{"col", "table"},
+		},
+		"DROP TABLE foo;\nALTER TABLE table DROP COLUMN col;\n",
+	)
+}
+
+func TestCreateTable(t *testing.T) {
+	assertChange(
+		t,
+		&CreateTable{mkTable(
+			"table",
+			mkCol("foo", SmallIntColumn, false, false, nil),
+			mkCol("bar", SerialColumn, false, false, nil),
+		)},
+		`CREATE TABLE table (
+foo smallint,
+bar serial
+);
+`)
+}
+
+func TestDropTable(t *testing.T) {
+	assertChange(
+		t,
+		&DropTable{"table"},
+		"DROP TABLE table;\n",
+	)
+}
+
+func TestAddColumn(t *testing.T) {
+	assertChange(
+		t,
+		&AddColumn{
+			mkCol("foo", SmallIntColumn, false, false, nil),
+			"table",
+		},
+		"ALTER TABLE table ADD COLUMN foo smallint;\n",
+	)
+}
+
+func TestDropColumn(t *testing.T) {
+	assertChange(
+		t,
+		&DropColumn{"col", "table"},
+		"ALTER TABLE table DROP COLUMN col;\n",
+	)
+}
+
+func TestManualChange(t *testing.T) {
+	assertChange(
+		t,
+		&ManualChange{"foo"},
+		"+++ THIS REQUIRES MANUAL MIGRATION: foo +++\n",
+	)
+}
+
+func assertChange(t *testing.T, c Change, expected string) {
+	output, err := c.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, expected, string(output))
+}
+
+func TestSchemaDiff(t *testing.T) {
+	old := mkModel(
+		mkTable("removed"),
+		mkTable(
+			"shared",
+			mkCol("foo", TextColumn, false, false, nil),
+		),
+	)
+
+	new := mkModel(
+		mkTable(
+			"shared",
+			mkCol("foo", TextColumn, false, false, nil),
+			mkCol("bar", TextColumn, false, false, nil),
+		),
+		mkTable("new"),
+	)
+
+	expected := ChangeSet{
+		&DropTable{"removed"},
+		&AddColumn{mkCol("bar", TextColumn, false, false, nil), "shared"},
+		&CreateTable{mkTable("new")},
+	}
+
+	require.Equal(t, expected, SchemaDiff(old, new))
+}
+
+func TestTableSchemaDiff(t *testing.T) {
+	old := mkTable(
+		"table",
+		mkCol("removed", TextColumn, false, false, nil),
+		mkCol("shared", TextColumn, false, false, nil),
+	)
+
+	new := mkTable(
+		"table",
+		mkCol("new", TextColumn, false, false, nil),
+		mkCol("shared", TextColumn, false, false, nil),
+	)
+
+	expected := ChangeSet{
+		&DropColumn{"removed", "table"},
+		&AddColumn{mkCol("new", TextColumn, false, false, nil), "table"},
+	}
+
+	require.Equal(t, expected, TableSchemaDiff(old, new))
+}
+
+func TestColumnSchemaDiff(t *testing.T) {
+	cases := []struct {
+		name                 string
+		old, new             *ColumnSchema
+		requiresManualChange bool
+	}{
+		{
+			"type change",
+			mkCol("foo", TextColumn, false, false, nil),
+			mkCol("foo", SmallIntColumn, false, false, nil),
+			true,
+		},
+		{
+			"pk change",
+			mkCol("foo", TextColumn, true, false, nil),
+			mkCol("foo", TextColumn, false, false, nil),
+			true,
+		},
+		{
+			"not null change",
+			mkCol("foo", TextColumn, false, true, nil),
+			mkCol("foo", TextColumn, false, false, nil),
+			true,
+		},
+		{
+			"ref added",
+			mkCol("foo", TextColumn, false, false, nil),
+			mkCol("foo", TextColumn, false, false, mkRef("foo", "bar")),
+			true,
+		},
+		{
+			"ref removed",
+			mkCol("foo", TextColumn, false, false, mkRef("foo", "bar")),
+			mkCol("foo", TextColumn, false, false, nil),
+			true,
+		},
+		{
+			"ref table changed",
+			mkCol("foo", TextColumn, false, false, mkRef("foo", "bar")),
+			mkCol("foo", TextColumn, false, false, mkRef("bar", "bar")),
+			true,
+		},
+		{
+			"ref col changed",
+			mkCol("foo", TextColumn, false, false, mkRef("foo", "bar")),
+			mkCol("foo", TextColumn, false, false, mkRef("foo", "foo")),
+			true,
+		},
+		{
+			"ref col unchanged",
+			mkCol("foo", TextColumn, false, false, mkRef("foo", "bar")),
+			mkCol("foo", TextColumn, false, false, mkRef("foo", "bar")),
+			false,
+		},
+		{
+			"equal",
+			mkCol("foo", TextColumn, false, false, nil),
+			mkCol("foo", TextColumn, false, false, nil),
+			false,
+		},
+	}
+
+	for _, c := range cases {
+		changes := ColumnSchemaDiff("Table", c.old, c.new)
+		if !c.requiresManualChange {
+			require.Len(t, changes, 0, c.name)
+		} else {
+			require.True(t, len(changes) > 0, c.name)
+		}
+	}
+}
+
+func TestReverseChange(t *testing.T) {
+	require := require.New(t)
+	old := mkModel(
+		mkTable(
+			"foo",
+			mkCol("bar", SmallIntColumn, false, false, nil),
+		),
+	)
+
+	cases := []struct {
+		original Change
+		expected Change
+	}{
+		{
+			&CreateTable{&TableSchema{Name: "foo"}},
+			&DropTable{Name: "foo"},
+		},
+		{
+			&DropTable{Name: "foo"},
+			&CreateTable{old.Table("foo")},
+		},
+		{
+			&AddColumn{
+				Table:  "foo",
+				Column: mkCol("bar", SmallIntColumn, false, false, nil),
+			},
+			&DropColumn{Table: "foo", Name: "bar"},
+		},
+		{
+			&DropColumn{Table: "foo", Name: "bar"},
+			&AddColumn{
+				Table:  "foo",
+				Column: mkCol("bar", SmallIntColumn, false, false, nil),
+			},
+		},
+		{
+			&ManualChange{"foo"},
+			&ManualChange{"foo"},
+		},
+	}
+
+	for _, c := range cases {
+		require.Equal(c.expected, reverseChange(c.original, old), "%T", c.original)
+	}
+}
+
+func mkModel(tables ...*TableSchema) *ModelSchema {
+	return &ModelSchema{tables}
+}
+
+func mkTable(name string, columns ...*ColumnSchema) *TableSchema {
+	return &TableSchema{name, columns}
+}
+
+func mkCol(name string, typ ColumnType, pk, notNull bool, ref *Reference) *ColumnSchema {
+	return &ColumnSchema{name, typ, pk, ref, notNull}
+}
+
+func mkRef(table, col string) *Reference {
+	return &Reference{table, col}
+}

--- a/generator/processor_test.go
+++ b/generator/processor_test.go
@@ -1,9 +1,6 @@
 package generator
 
 import (
-	"go/ast"
-	"go/parser"
-	"go/token"
 	"go/types"
 	"reflect"
 	"testing"
@@ -318,24 +315,14 @@ func (s *ProcessorSuite) TestIsSQLType() {
 }
 
 func (s *ProcessorSuite) processorFixture(source string) *Processor {
-	fset := &token.FileSet{}
-	astFile, err := parser.ParseFile(fset, "fixture.go", source, 0)
-	s.Nil(err)
-
-	cfg := &types.Config{
-		Importer: parseutil.NewImporter(),
-	}
-	p, err := cfg.Check("foo", fset, []*ast.File{astFile}, nil)
-	s.Nil(err)
-
-	prc := NewProcessor("fixture", []string{"foo.go"})
-	prc.Package = p
+	prc, err := processorFixture(source)
+	s.Require().NoError(err)
 	return prc
 }
 
 func (s *ProcessorSuite) processFixture(source string) *Package {
-	pkg, err := s.processorFixture(source).processPackage()
-	s.Nil(err)
+	pkg, err := processFixture(source)
+	s.Require().NoError(err)
 	return pkg
 }
 

--- a/generator/types.go
+++ b/generator/types.go
@@ -791,6 +791,10 @@ func (f *Field) TypeSchemaName() string {
 	return parts[len(parts)-1]
 }
 
+func (f *Field) SQLType() string {
+	return f.Tag.Get("sqltype")
+}
+
 var identifierTypes = map[string]string{
 	"gopkg.in/src-d/go-kallax.v1.UUID":      "kallax.UUID",
 	"gopkg.in/src-d/go-kallax.v1.ULID":      "kallax.ULID",

--- a/tests/query.go
+++ b/tests/query.go
@@ -41,13 +41,13 @@ type QueryFixture struct {
 	AliasDummyParam           fixtures.AliasDummyParam
 	SliceDummyParam           []fixtures.QueryDummy
 	IDPropertyParam           kallax.ULID
-	InterfacePropParam        fixtures.InterfaceImplementation
+	InterfacePropParam        fixtures.InterfaceImplementation `sqltype:"jsonb"`
 	URLParam                  url.URL
 	TimeParam                 time.Time
 	AliasArrAliasStringParam  fixtures.AliasArrAliasString
 	AliasHereArrayParam       AliasHereArray
 	ArrayAliasHereStringParam []AliasHereString
-	ScannerValuerParam        ScannerValuer
+	ScannerValuerParam        ScannerValuer `sqltype:"jsonb"`
 }
 
 type AliasHereString string


### PR DESCRIPTION
Closes #145 

### Design overview

There are three types of migrations involved in migrations:
* `lock.json`: contains the latest version of the SQL schema. Every new generation, takes it from there and diffs the current schema inferred from the models against it.
* `TS_name.up.sql`: an up script for a migration.
* `TS_name.down.sql`: a down script for a migration.

### Flow

* Lock file is read.
* Models are processed and converted to a SQL schema (tables and columns).
* Diff between lock schema and current schema produces the change set for the up migration.
* With the up migration, the inverse of the changes are made and this is the down migration.
* With the up and down migrations and the current schema, three files are generated:
  * New lock with the current schema.
  * New up script.
  * New down script.

### Caveats

* A new struct tag for fields is introduced: `sqltype`. There are some cases in which we can't know which SQL corresponds to a Go type, for example, in `sql.Valuer`s. In this case, the generation will fail and the user will have to use a custom type.
* There are some cases where tracking certain changes are hard for us to do automatically, and thus, require manual change. There is a type of change named `ManualChange` that generates invalid SQL syntax (with a human-readable message so the user knows why the manual change is required) so the user can't run the migrations until a proper migration is done manually.
* Renames can't be tracked in neither tables nor columns, so they are a DROP+CREATE instead.

### Missing features

* This only introduces the generation of migrations, not their execution! That will be done in a followup PR.
* Once this is merged and finalized I will make a followup PR with the documentation for this feature.