### PR TITLE
execute migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ type Metadata struct {
 
 | Tag | Description | Can be used in |
 | --- | --- | --- |
-| `table"table_name"` | Specifies the name of the table for a model. If not provided, the name of the table will be the name of the struct in lower snake case (e.g. `UserPreference` => `user_preference`) | embedded `kallax.Model` |
+| `table:"table_name"` | Specifies the name of the table for a model. If not provided, the name of the table will be the name of the struct in lower snake case (e.g. `UserPreference` => `user_preference`) | embedded `kallax.Model` |
 | `pk:""` | Specifies the field is a primary key | any field with a valid identifier type |
 | `pk:"autoincr"` | Specifies the field is an auto-incrementable primary key | any field with a valid identifier type |
 | `kallax:"column_name"` | Specifies the name of the column | Any model field that is not a relationship |

--- a/README.md
+++ b/README.md
@@ -601,6 +601,7 @@ store.Transaction(func(s *UserStore) error {
   For example, consider the following type `type Foo string`, using `[]Foo` would not be supported. Know that this will fail during the scanning of rows and not in code-generation time for now. In the future, might be moved to a warning or an error during code generation.
   Aliases of slice types are supported, though. If we have `type Strings []string`, using `Strings` would be supported, as a cast like this `([]string)(&slice)` it's supported and `[]string` is supported.
 * `time.Time` and `url.URL` need to be used as is. That is, you can not use a type `Foo` being `type Foo time.Time`. `time.Time` and `url.URL` are types that are treated in a special way, if you do that, it would be the same as saying `type Foo struct { ... }` and kallax would no longer be able to identify the correct type.
+* `time.Time` fields will be truncated to remove its nanoseconds on `Save`, `Insert` or `Update`, since PostgreSQL will not be able to store them. PostgreSQL stores times with timezones as UTC internally. So, times will come back as UTC (you can use `Local` method to convert them back to the local timezone). You can change the timezone that will be used to bring times back from the database in [the PostgreSQL configuration](https://www.postgresql.org/docs/9.6/static/datatype-datetime.html).
 * Multidimensional arrays or slices are **not supported** except inside a JSON field.
 
 ## Debug SQL queries

--- a/generator/cli/kallax/cmd.go
+++ b/generator/cli/kallax/cmd.go
@@ -1,147 +1,30 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
 
-	"gopkg.in/src-d/go-kallax.v1/generator"
+	"gopkg.in/src-d/go-kallax.v1/generator/cli/kallax/cmd"
 
 	"gopkg.in/urfave/cli.v1"
 )
 
+const version = "1.1.4"
+
 func main() {
+	newApp().Run(os.Args)
+}
+
+func newApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = "kallax"
-	app.Version = "1.1.4"
+	app.Version = version
 	app.Usage = "generate kallax models"
-	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:  "input",
-			Value: ".",
-			Usage: "Input package directory",
-		},
-		cli.StringFlag{
-			Name:  "output",
-			Value: "kallax.go",
-			Usage: "Output file name",
-		},
-		cli.StringSliceFlag{
-			Name:  "exclude, e",
-			Usage: "List of excluded files from the package when generating the code for your models. Use this to exclude files in your package that uses the generated code. You can use this flag as many times as you want.",
-		},
-	}
-	app.Action = generateModels
-	app.Commands = []cli.Command{
-		{
-			Name:   "gen",
-			Usage:  "Generate kallax models",
-			Action: generateModels,
-			Flags:  app.Flags,
-		},
-		{
-			Name:   "migrate",
-			Usage:  "Generate migrations for current kallax models",
-			Action: migrateAction,
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "out, o",
-					Usage: "Output directory of migrations",
-				},
-				cli.StringFlag{
-					Name:  "name, n",
-					Usage: "Descriptive name for the migration",
-					Value: "migration",
-				},
-				cli.StringSliceFlag{
-					Name:  "input, i",
-					Usage: "List of directories to scan models from. You can use this flag as many times as you want.",
-				},
-			},
-		},
+	app.Flags = cmd.Generate.Flags
+	app.Action = cmd.Generate.Action
+	app.Commands = cli.Commands{
+		cmd.Generate,
+		cmd.Migrate,
 	}
 
-	app.Run(os.Args)
-}
-
-func generateModels(c *cli.Context) error {
-	input := c.String("input")
-	output := c.String("output")
-	excluded := c.StringSlice("exclude")
-
-	ok, err := isDirectory(input)
-	if err != nil {
-		return fmt.Errorf("kallax: can't check input directory: %s", err)
-	}
-
-	if !ok {
-		return fmt.Errorf("kallax: Input path should be a directory %s", input)
-	}
-
-	p := generator.NewProcessor(input, excluded)
-	pkg, err := p.Do()
-	if err != nil {
-		return err
-	}
-
-	gen := generator.NewGenerator(filepath.Join(input, output))
-	err = gen.Generate(pkg)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func migrateAction(c *cli.Context) error {
-	dirs := c.StringSlice("input")
-	dir := c.String("out")
-	name := c.String("name")
-
-	var pkgs []*generator.Package
-	for _, dir := range dirs {
-		ok, err := isDirectory(dir)
-		if err != nil {
-			return fmt.Errorf("kallax: cannot check directory in `input`: %s", err)
-		}
-
-		if !ok {
-			return fmt.Errorf("kallax: `input` must be a valid directory")
-		}
-
-		p := generator.NewProcessor(dir, nil)
-		p.Silent()
-		pkg, err := p.Do()
-		if err != nil {
-			return err
-		}
-
-		pkgs = append(pkgs, pkg)
-	}
-
-	ok, err := isDirectory(dir)
-	if err != nil {
-		return fmt.Errorf("kallax: cannot check directory in `out`: %s", err)
-	}
-
-	if !ok {
-		return fmt.Errorf("kallax: `out` must be a valid directory")
-	}
-
-	g := generator.NewMigrationGenerator(name, dir)
-	migration, err := g.Build(pkgs...)
-	if err != nil {
-		return err
-	}
-
-	return g.Generate(migration)
-}
-
-func isDirectory(name string) (bool, error) {
-	info, err := os.Stat(name)
-	if err != nil {
-		return false, err
-	}
-
-	return info.IsDir(), nil
+	return app
 }

--- a/generator/cli/kallax/cmd/gen.go
+++ b/generator/cli/kallax/cmd/gen.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"gopkg.in/src-d/go-kallax.v1/generator"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+var Generate = cli.Command{
+	Name:   "gen",
+	Usage:  "Generate kallax models",
+	Action: generateAction,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "input",
+			Value: ".",
+			Usage: "Input package directory",
+		},
+		cli.StringFlag{
+			Name:  "output",
+			Value: "kallax.go",
+			Usage: "Output file name",
+		},
+		cli.StringSliceFlag{
+			Name:  "exclude, e",
+			Usage: "List of excluded files from the package when generating the code for your models. Use this to exclude files in your package that uses the generated code. You can use this flag as many times as you want.",
+		},
+	},
+}
+
+func generateAction(c *cli.Context) error {
+	input := c.String("input")
+	output := c.String("output")
+	excluded := c.StringSlice("exclude")
+
+	ok, err := isDirectory(input)
+	if err != nil {
+		return fmt.Errorf("kallax: can't check input directory: %s", err)
+	}
+
+	if !ok {
+		return fmt.Errorf("kallax: Input path should be a directory %s", input)
+	}
+
+	p := generator.NewProcessor(input, excluded)
+	pkg, err := p.Do()
+	if err != nil {
+		return err
+	}
+
+	gen := generator.NewGenerator(filepath.Join(input, output))
+	err = gen.Generate(pkg)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/generator/cli/kallax/cmd/migrate.go
+++ b/generator/cli/kallax/cmd/migrate.go
@@ -97,11 +97,11 @@ func upAction(m *migrate.Migrate, steps, version uint, all bool) error {
 func downAction(m *migrate.Migrate, steps, version uint, all bool) error {
 	if version > 0 {
 		if err := m.Migrate(version); err != nil {
-			return fmt.Errorf("kallax: unable to upgrade up to version %d: %s", version, err)
+			return fmt.Errorf("kallax: unable to rollback to version %d: %s", version, err)
 		}
 	} else if steps > 0 {
 		if err := m.Steps(-int(steps)); err != nil {
-			return fmt.Errorf("kallax: unable to execute %d migration(s) up: %s", steps, err)
+			return fmt.Errorf("kallax: unable to execute %d migration(s) down: %s", steps, err)
 		}
 	} else {
 		return fmt.Errorf("kallax: no `version` or `steps` provided. You need to specify one of them.")

--- a/generator/cli/kallax/cmd/migrate.go
+++ b/generator/cli/kallax/cmd/migrate.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/mattes/migrate"
+	_ "github.com/mattes/migrate/database/postgres"
+	_ "github.com/mattes/migrate/source/file"
+
+	"gopkg.in/src-d/go-kallax.v1/generator"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+var Migrate = cli.Command{
+	Name:   "migrate",
+	Usage:  "Generate migrations for current kallax models",
+	Action: migrateAction,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "out, o",
+			Usage: "Output directory of migrations",
+		},
+		cli.StringFlag{
+			Name:  "name, n",
+			Usage: "Descriptive name for the migration",
+			Value: "migration",
+		},
+		cli.StringSliceFlag{
+			Name:  "input, i",
+			Usage: "List of directories to scan models from. You can use this flag as many times as you want.",
+		},
+	},
+	Subcommands: cli.Commands{
+		Up,
+		Down,
+	},
+}
+
+var migrationFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "dir, d",
+		Value: "./migrations",
+		Usage: "Directory where your migrations are stored",
+	},
+	cli.StringFlag{
+		Name:  "dsn",
+		Usage: "PostgreSQL data source name. Example: `user:pass@localhost:5432/database?sslmode=enable`",
+	},
+	cli.UintFlag{
+		Name:  "steps, n",
+		Usage: "Number of migrations to run",
+	},
+	cli.UintFlag{
+		Name:  "version, v",
+		Usage: "Migrate to a specific version. If `steps` and this flag are given, this will be used.",
+	},
+}
+
+var Up = cli.Command{
+	Name:   "up",
+	Usage:  "Executes the migrations from the current version until the specified version.",
+	Action: runMigrationAction(upAction),
+	Flags:  migrationFlags,
+}
+
+var Down = cli.Command{
+	Name:   "down",
+	Usage:  "Downgrades the database a certain number of migrations or until a certain version.",
+	Action: runMigrationAction(downAction),
+	Flags:  migrationFlags,
+}
+
+func upAction(m *migrate.Migrate, steps, version uint) error {
+	if version > 0 {
+		if err := m.Migrate(version); err != nil {
+			return fmt.Errorf("kallax: unable to upgrade up to version %d: %s", version, err)
+		}
+	} else if steps > 0 {
+		if err := m.Steps(int(steps)); err != nil {
+			return fmt.Errorf("kallax: unable to execute %d migration(s) up: %s", steps, err)
+		}
+	} else {
+		fmt.Println("WARN: No `version` or `steps` provided, upgrading all the way up.")
+		if err := m.Up(); err != nil {
+			return fmt.Errorf("kallax: unable to upgrade the database all the way up: %s", err)
+		}
+	}
+	reportMigrationSuccess(m)
+	return nil
+}
+
+func downAction(m *migrate.Migrate, steps, version uint) error {
+	if version > 0 {
+		if err := m.Migrate(version); err != nil {
+			return fmt.Errorf("kallax: unable to upgrade up to version %d: %s", version, err)
+		}
+	} else if steps > 0 {
+		if err := m.Steps(-int(steps)); err != nil {
+			return fmt.Errorf("kallax: unable to execute %d migration(s) up: %s", steps, err)
+		}
+	} else {
+		return fmt.Errorf("kallax: no `version` or `steps` provided. You need to specify one of them.")
+	}
+	reportMigrationSuccess(m)
+	return nil
+}
+
+func reportMigrationSuccess(m *migrate.Migrate) {
+	fmt.Println("Success! the migration has been run.")
+
+	if v, _, err := m.Version(); err != nil {
+		fmt.Printf("Unable to check the latest version of the database: %s.\n", err)
+	} else {
+		fmt.Printf("Database is now at version %d.\n", v)
+	}
+}
+
+type runMigrationFunc func(m *migrate.Migrate, steps, version uint) error
+
+func runMigrationAction(fn runMigrationFunc) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		var (
+			dir     = c.String("dir")
+			dsn     = c.String("dsn")
+			steps   = c.Uint("steps")
+			version = c.Uint("version")
+		)
+
+		ok, err := isDirectory(dir)
+		if err != nil {
+			return fmt.Errorf("kallax: cannot check if `dir` is a directory: %s", err)
+		}
+
+		if !ok {
+			return fmt.Errorf("kallax: argument `dir` must be a valid directory")
+		}
+
+		dir, err = filepath.Abs(dir)
+		if err != nil {
+			return fmt.Errorf("kallax: cannot get absolute path of `dir`: %s", err)
+		}
+
+		m, err := migrate.New(fmt.Sprintf("file://%s", dir), fmt.Sprintf("postgres://%s", dsn))
+		if err != nil {
+			return fmt.Errorf("kallax: unable to open a connection with the database: %s", err)
+		}
+
+		return fn(m, steps, version)
+	}
+}
+
+func migrateAction(c *cli.Context) error {
+	dirs := c.StringSlice("input")
+	dir := c.String("out")
+	name := c.String("name")
+
+	var pkgs []*generator.Package
+	for _, dir := range dirs {
+		ok, err := isDirectory(dir)
+		if err != nil {
+			return fmt.Errorf("kallax: cannot check directory in `input`: %s", err)
+		}
+
+		if !ok {
+			return fmt.Errorf("kallax: `input` must be a valid directory")
+		}
+
+		p := generator.NewProcessor(dir, nil)
+		p.Silent()
+		pkg, err := p.Do()
+		if err != nil {
+			return err
+		}
+
+		pkgs = append(pkgs, pkg)
+	}
+
+	ok, err := isDirectory(dir)
+	if err != nil {
+		return fmt.Errorf("kallax: cannot check directory in `out`: %s", err)
+	}
+
+	if !ok {
+		return fmt.Errorf("kallax: `out` must be a valid directory")
+	}
+
+	g := generator.NewMigrationGenerator(name, dir)
+	migration, err := g.Build(pkgs...)
+	if err != nil {
+		return err
+	}
+
+	return g.Generate(migration)
+}

--- a/generator/cli/kallax/cmd/util.go
+++ b/generator/cli/kallax/cmd/util.go
@@ -1,0 +1,12 @@
+package cmd
+
+import "os"
+
+func isDirectory(name string) (bool, error) {
+	info, err := os.Stat(name)
+	if err != nil {
+		return false, err
+	}
+
+	return info.IsDir(), nil
+}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -95,7 +95,7 @@ func (g *MigrationGenerator) Build(pkgs ...*Package) (*Migration, error) {
 		return nil, err
 	}
 
-	return NewMigration(old, new), nil
+	return NewMigration(old, new)
 }
 
 // Generate will generate the given migration.

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -21,7 +21,7 @@ func TestMigrationGeneratorLoadLock(t *testing.T) {
 	require.NotNil(t, schema)
 	require.Len(t, schema.Tables, 0)
 
-	content, err := mkModel(mkTable("foo")).MarshalText()
+	content, err := mkSchema(mkTable("foo")).MarshalText()
 	require.NoError(t, err)
 
 	err = ioutil.WriteFile(filepath.Join(dir, string(migrationLock)), content, 0755)
@@ -39,7 +39,7 @@ func TestMigrationGeneratorBuild(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	g := NewMigrationGenerator("migration", dir)
-	content, err := mkModel(mkTable("foo")).MarshalText()
+	content, err := mkSchema(mkTable("foo")).MarshalText()
 	require.NoError(t, err)
 
 	err = ioutil.WriteFile(filepath.Join(dir, string(migrationLock)), content, 0755)
@@ -51,9 +51,10 @@ func TestMigrationGeneratorBuild(t *testing.T) {
 }
 
 func TestMigrationGeneratorGenerate(t *testing.T) {
-	old := mkModel(table1)
-	new := mkModel(table1, table2)
-	migration := NewMigration(old, new)
+	old := mkSchema(table1)
+	new := mkSchema(table1, table2)
+	migration, err := NewMigration(old, new)
+	require.NoError(t, err)
 
 	dir, err := ioutil.TempDir("", "kallax-migration-generator")
 	require.NoError(t, err)

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -70,11 +70,11 @@ func TestMigrationGeneratorGenerate(t *testing.T) {
 
 	content, err := ioutil.ReadFile(g.migrationFile(migrationUp, g.now()))
 	require.NoError(t, err)
-	require.Equal(t, expectedTable2+"\n\n", string(content))
+	require.Equal(t, "BEGIN;\n\n"+expectedTable2+"\n\nCOMMIT;\n", string(content))
 
 	content, err = ioutil.ReadFile(g.migrationFile(migrationDown, g.now()))
 	require.NoError(t, err)
-	require.Equal(t, "DROP TABLE table2;\n\n", string(content))
+	require.Equal(t, "BEGIN;\n\nDROP TABLE table2;\n\nCOMMIT;\n", string(content))
 
 	expected, err := migration.Lock.MarshalText()
 	require.NoError(t, err)

--- a/generator/migration.go
+++ b/generator/migration.go
@@ -323,6 +323,7 @@ func (cs ChangeSet) sorted(dropIndex, createIndex map[string]*TableSchema) (Chan
 
 func (cs ChangeSet) MarshalText() ([]byte, error) {
 	var buf bytes.Buffer
+	buf.WriteString("BEGIN;\n\n")
 	for _, c := range cs {
 		bytes, err := c.MarshalText()
 		if err != nil {
@@ -331,6 +332,7 @@ func (cs ChangeSet) MarshalText() ([]byte, error) {
 		buf.Write(bytes)
 		buf.WriteRune('\n')
 	}
+	buf.WriteString("COMMIT;\n")
 	return buf.Bytes(), nil
 }
 

--- a/generator/migration.go
+++ b/generator/migration.go
@@ -19,12 +19,29 @@ type Migration struct {
 }
 
 // NewMigration creates a new migration from the old and the new schema.
-func NewMigration(old, new *DBSchema) *Migration {
-	var migration = &Migration{}
-	migration.Up = SchemaDiff(old, new)
-	migration.Down = migration.Up.ReverseChangeSet(old)
+func NewMigration(old, new *DBSchema) (*Migration, error) {
+	var (
+		migration = &Migration{}
+		err       error
+		oldTables = old.index()
+		newTables = new.index()
+	)
+
+	migration.Up, err = SchemaDiff(old, new).
+		sorted(oldTables, newTables)
+	if err != nil {
+		return nil, err
+	}
+
+	migration.Down, err = migration.Up.
+		ReverseChangeSet(old).
+		sorted(newTables, oldTables)
+	if err != nil {
+		return nil, err
+	}
+
 	migration.Lock = new
-	return migration
+	return migration, nil
 }
 
 // DBSchema represents a schema of all the models in the database.
@@ -56,12 +73,34 @@ func (s *DBSchema) Table(name string) *TableSchema {
 	return nil
 }
 
+func (s *DBSchema) index() map[string]*TableSchema {
+	var result = make(map[string]*TableSchema)
+	for _, t := range s.Tables {
+		result[t.Name] = t
+	}
+	return result
+}
+
 // TableSchema represents the SQL schema of a table.
 type TableSchema struct {
 	// Name is the table name.
 	Name string
 	// Columns are the schemas of the columns in the table.
 	Columns []*ColumnSchema
+}
+
+func (s *TableSchema) relationships() []string {
+	var rels = make(map[string]struct{})
+	var result []string
+	for _, c := range s.Columns {
+		if c.Reference != nil {
+			if _, ok := rels[c.Reference.Table]; !ok {
+				result = append(result, c.Reference.Table)
+				rels[c.Reference.Table] = struct{}{}
+			}
+		}
+	}
+	return result
 }
 
 func (s *TableSchema) String() string {
@@ -210,6 +249,78 @@ func (r *Reference) String() string {
 // ChangeSet is a set of changes to be made in a migration.
 type ChangeSet []Change
 
+// sorted sorts the given changeset with the given order:
+// - first the create tables ordered by their relationships. For example,
+//  if profiles depends on
+//   users, users will be created first, and then profiles.
+// - second the drop tables, ordered in reverse order by their relationships.
+//   For example, if profiles depends on users, profiles will be removed first
+//   and then users.
+// - Finally, rest of the changes.
+// dropIndex and createIndex are indexes of table name to table schema
+// used to look for dependencies of changes in drops and creates respectively.
+func (cs ChangeSet) sorted(dropIndex, createIndex map[string]*TableSchema) (ChangeSet, error) {
+	var (
+		createTables = make(map[string]Change)
+		dropTables   = make(map[string]Change)
+		createGraph  = newGraph()
+		dropGraph    = newGraph()
+		others       ChangeSet
+		result       ChangeSet
+	)
+
+	for _, c := range cs {
+		switch c := c.(type) {
+		case *CreateTable:
+			createTables[c.Name] = c
+			if rels := createIndex[c.Name].relationships(); len(rels) > 0 {
+				for _, r := range rels {
+					createGraph.dependsOn(r, c.Name)
+				}
+			} else {
+				createGraph.add(c.Name)
+			}
+		case *DropTable:
+			dropTables[c.Name] = c
+			if rels := dropIndex[c.Name].relationships(); len(rels) > 0 {
+				for _, r := range rels {
+					dropGraph.dependsOn(r, c.Name)
+				}
+			} else {
+				dropGraph.add(c.Name)
+			}
+		default:
+			others = append(others, c)
+		}
+	}
+
+	creates, err := createGraph.resolve()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range creates {
+		if change, ok := createTables[c]; ok {
+			result = append(result, change)
+		}
+	}
+
+	drops, err := dropGraph.resolve()
+	if err != nil {
+		return nil, err
+	}
+
+	drops = reverse(drops)
+	for _, d := range drops {
+		if change, ok := dropTables[d]; ok {
+			result = append(result, change)
+		}
+	}
+
+	result = append(result, others...)
+	return result, nil
+}
+
 func (cs ChangeSet) MarshalText() ([]byte, error) {
 	var buf bytes.Buffer
 	for _, c := range cs {
@@ -356,6 +467,103 @@ func (c *ManualChange) MarshalText() ([]byte, error) {
 	return []byte(fmt.Sprintf("+++ THIS REQUIRES MANUAL MIGRATION: %s +++\n", c.Msg)), nil
 }
 
+type graph struct {
+	nodeList []string
+	nodes    map[string]*node
+}
+
+type resolutionCtx struct {
+	resolved   map[string]struct{}
+	unresolved map[string]struct{}
+	names      []string
+}
+
+func newGraph() *graph {
+	return &graph{nil, make(map[string]*node)}
+}
+
+// add adds a new root node that has no dependencies.
+func (g *graph) add(name string) *graph {
+	if _, ok := g.nodes[name]; !ok {
+		g.nodeList = append(g.nodeList, name)
+		g.nodes[name] = newNode(name)
+	}
+	return g
+}
+
+func (g *graph) dependsOn(dependant, dependency string) *graph {
+	g.node(dependency).addDependant(g.node(dependant))
+	g.node(dependant).addDependency(g.node(dependency))
+	return g
+}
+
+func (g *graph) node(name string) *node {
+	g.add(name)
+	return g.nodes[name]
+}
+
+func (g *graph) resolve() ([]string, error) {
+	ctx := &resolutionCtx{
+		make(map[string]struct{}),
+		make(map[string]struct{}),
+		nil,
+	}
+
+	for _, n := range g.nodeList {
+		node := g.nodes[n]
+		if len(node.dependencies) == 0 {
+			if err := g.nodes[n].resolve(ctx); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if len(g.nodes) != len(ctx.names) {
+		return nil, fmt.Errorf("kallax: unable to resolve all the table dependencies. There is probably a circular dependency somewhere.")
+	}
+
+	return ctx.names, nil
+}
+
+type node struct {
+	name         string
+	dependants   []*node
+	dependencies []*node
+}
+
+func newNode(name string) *node {
+	return &node{name, nil, nil}
+}
+
+func (n *node) addDependant(node *node) {
+	n.dependants = append(n.dependants, node)
+}
+
+func (n *node) addDependency(node *node) {
+	n.dependencies = append(n.dependencies, node)
+}
+
+func (n *node) resolve(ctx *resolutionCtx) error {
+	ctx.unresolved[n.name] = struct{}{}
+
+	for _, dep := range n.dependants {
+		if _, ok := ctx.resolved[dep.name]; !ok {
+			if _, ok := ctx.unresolved[dep.name]; ok {
+				return fmt.Errorf("kallax: there is a circular dependency between %s and %s", n.name, dep.name)
+			}
+
+			if err := dep.resolve(ctx); err != nil {
+				return err
+			}
+		}
+	}
+
+	delete(ctx.unresolved, n.name)
+	ctx.resolved[n.name] = struct{}{}
+	ctx.names = append(ctx.names, n.name)
+	return nil
+}
+
 // SchemaDiff generates a change set with the diff between two schemas.
 func SchemaDiff(old, new *DBSchema) ChangeSet {
 	var cs ChangeSet
@@ -452,9 +660,9 @@ type packageTransformer struct {
 	tableIndex map[string]string
 	// pkIndex is a map from a table name to its primary key
 	pkIndex map[string]*Field
-	// inverses keeps all inverses indexed by type name
+	// fks keeps all fks indexed by type name
 	// so they can be added later.
-	inverses map[string][]*ColumnSchema
+	fks map[string][]*ColumnSchema
 }
 
 func newPackageTransformer() *packageTransformer {
@@ -463,7 +671,7 @@ func newPackageTransformer() *packageTransformer {
 		tables:     make(map[string]*TableSchema),
 		tableIndex: make(map[string]string),
 		pkIndex:    make(map[string]*Field),
-		inverses:   make(map[string][]*ColumnSchema),
+		fks:        make(map[string][]*ColumnSchema),
 	}
 }
 
@@ -482,28 +690,28 @@ func (t *packageTransformer) transform(pkgs ...*Package) (*DBSchema, error) {
 		}
 	}
 
-	if err := t.applyInverses(); err != nil {
+	if err := t.applyForeignKeys(); err != nil {
 		return nil, err
 	}
 
 	return t.schema, nil
 }
 
-func (t *packageTransformer) applyInverses() error {
-	for typ, inverses := range t.inverses {
+func (t *packageTransformer) applyForeignKeys() error {
+	for typ, fks := range t.fks {
 		table, ok := t.tableIndex[typ]
 		if !ok {
 			return fmt.Errorf("kallax: unable to find a table for model %s. Is the model package on the input for this command?", typ)
 		}
 
 		schema := t.tables[table]
-		for _, inv := range inverses {
-			if col := schema.Column(inv.Name); col != nil {
-				if !col.Equals(inv) {
-					return fmt.Errorf("kallax: there is an inverse definition conflicting with the column definition of column %s in the table %s. Please, make sure both definitions match.", inv.Name, table)
+		for _, fk := range fks {
+			if col := schema.Column(fk.Name); col != nil {
+				if !col.Equals(fk) {
+					return fmt.Errorf("kallax: there is an inverse definition conflicting with the column definition of column %s in the table %s. Please, make sure both definitions match.", fk.Name, table)
 				}
 			} else {
-				schema.Columns = append(schema.Columns, inv)
+				schema.Columns = append(schema.Columns, fk)
 			}
 		}
 	}
@@ -556,9 +764,9 @@ func (t *packageTransformer) transformFields(fields []*Field, columns map[string
 				return nil, err
 			}
 
-			if f.Kind == Relationship && f.IsInverse() {
+			if f.Kind == Relationship && !f.IsInverse() {
 				typ := removeTypePrefix(f.Type)
-				t.inverses[typ] = append(t.inverses[typ], column)
+				t.fks[typ] = append(t.fks[typ], column)
 			} else if col, ok := columns[f.ColumnName()]; ok {
 				if !col.Equals(column) {
 					return nil, fmt.Errorf("kallax: there are two conflicting definitions for column %s on table %s: \n- %s\n- %s", col.Name, f.Model.Table, col, column)
@@ -628,7 +836,7 @@ func (t *packageTransformer) transformType(f *Field, pk bool) (ColumnType, error
 		return typ, nil
 	}
 
-	if f.Kind == Relationship && !f.IsInverse() {
+	if f.Kind == Relationship && f.IsInverse() {
 		typ := removeTypePrefix(f.Type)
 		table, ok := t.tableIndex[typ]
 		if !ok {
@@ -653,7 +861,7 @@ func (t *packageTransformer) transformType(f *Field, pk bool) (ColumnType, error
 }
 
 func (t *packageTransformer) transformRef(f *Field) (*Reference, error) {
-	if f.Kind == Relationship && !f.IsInverse() {
+	if f.Kind == Relationship && f.IsInverse() {
 		typ := removeTypePrefix(f.Type)
 		table, ok := t.tableIndex[typ]
 		if !ok {
@@ -698,4 +906,13 @@ var idTypeMappings = map[string]ColumnType{
 	"kallax.ULID":      UUIDColumn,
 	"kallax.UUID":      UUIDColumn,
 	"kallax.NumericID": SerialColumn,
+}
+
+func reverse(slice []string) []string {
+	result := make([]string, len(slice))
+	len := len(slice)
+	for i := len - 1; i >= 0; i-- {
+		result[i] = slice[len-1-i]
+	}
+	return result
 }

--- a/generator/migration_test.go
+++ b/generator/migration_test.go
@@ -62,7 +62,7 @@ func TestChangeSet(t *testing.T) {
 			&DropTable{"foo"},
 			&DropColumn{"col", "table"},
 		},
-		"DROP TABLE foo;\n\nALTER TABLE table DROP COLUMN col;\n\n",
+		"BEGIN;\n\nDROP TABLE foo;\n\nALTER TABLE table DROP COLUMN col;\n\nCOMMIT;\n",
 	)
 }
 

--- a/generator/migration_test.go
+++ b/generator/migration_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 func TestNewMigration(t *testing.T) {
-	old := mkModel(table1)
-	new := mkModel(table1, table2)
-	migration := NewMigration(old, new)
+	old := mkSchema(table1)
+	new := mkSchema(table1, table2)
+	migration, err := NewMigration(old, new)
+	require.NoError(t, err)
 
 	expectedUp := ChangeSet{&CreateTable{table2}}
 	expectedDown := ChangeSet{&DropTable{"table2"}}
@@ -123,7 +124,7 @@ func assertChange(t *testing.T, c Change, expected string) {
 }
 
 func TestSchemaDiff(t *testing.T) {
-	old := mkModel(
+	old := mkSchema(
 		mkTable("removed"),
 		mkTable(
 			"shared",
@@ -131,7 +132,7 @@ func TestSchemaDiff(t *testing.T) {
 		),
 	)
 
-	new := mkModel(
+	new := mkSchema(
 		mkTable(
 			"shared",
 			mkCol("foo", TextColumn, false, false, nil),
@@ -244,7 +245,7 @@ func TestColumnSchemaDiff(t *testing.T) {
 
 func TestReverseChange(t *testing.T) {
 	require := require.New(t)
-	old := mkModel(
+	old := mkSchema(
 		mkTable(
 			"foo",
 			mkCol("bar", SmallIntColumn, false, false, nil),
@@ -401,6 +402,36 @@ func TestColumnSchemaEquals(t *testing.T) {
 	}
 }
 
+func TestChangeSetSorted(t *testing.T) {
+	old := mkSchema(
+		mkTable("table2"),
+		mkTable(
+			"table1",
+			mkCol("foo", SerialColumn, false, false, mkRef("table2", "bar")),
+		),
+		mkTable("table3"),
+	)
+	new := mkSchema(
+		mkTable("table3"),
+		mkTable("table4"),
+		mkTable(
+			"table5",
+			mkCol("foo", SerialColumn, false, false, mkRef("table4", "bar")),
+		),
+	)
+	cs := SchemaDiff(old, new)
+	expected := ChangeSet{
+		&CreateTable{new.Table("table4")},
+		&CreateTable{new.Table("table5")},
+		&DropTable{"table1"},
+		&DropTable{"table2"},
+	}
+
+	sorted, err := cs.sorted(old.index(), new.index())
+	require.NoError(t, err)
+	require.Equal(t, expected, sorted)
+}
+
 type PackageTransformerSuite struct {
 	suite.Suite
 	t   *packageTransformer
@@ -421,9 +452,7 @@ type User struct {
 	Username string
 	// array field
 	Emails []string
-	// user_id should not be added twice on profile,
-	// even though it is defined as an inverse here
-	Profile *Profile ` + "`fk:\"user_id,inverse\"`" + `
+	Profile *Profile
 }
 
 type Profile struct {
@@ -431,12 +460,14 @@ type Profile struct {
 	ID int64 ` + "`pk:\"autoincr\"`" + `
 	Color string ` + "`sqltype:\"char(6)\"`" + `
 	Background url.URL
-	User *User ` + "`fk:\"user_id\"`" + `
+	// should be added here because is an inverse and not
+	// in user
+	User *User ` + "`fk:\"user_id,inverse\"`" + `
 	Spouse *kallax.ULID
-	// an inverse without reference in the other model
+	// a fk without reference in the other model
 	// should be added anyway
 	// should be added as bigint, as it is not a pk
-	Metadata *ProfileMetadata ` + "`fk:\"profile_id,inverse\"`" + `
+	Metadata *ProfileMetadata
 }
 
 type ProfileMetadata struct {
@@ -461,7 +492,7 @@ func (s *PackageTransformerSuite) TestTransform() {
 	require.NoError(err)
 	require.NotNil(schema)
 
-	expected := mkModel(
+	expected := mkSchema(
 		mkTable(
 			"profiles",
 			mkCol("id", SerialColumn, true, false, nil),
@@ -488,15 +519,15 @@ func (s *PackageTransformerSuite) TestTransform() {
 }
 
 func (s *PackageTransformerSuite) TestApplyInverses_TableNotFound() {
-	s.t.inverses["foo"] = []*ColumnSchema{
+	s.t.fks["foo"] = []*ColumnSchema{
 		mkCol("foo", TextColumn, false, false, nil),
 	}
 
-	s.Error(s.t.applyInverses())
+	s.Error(s.t.applyForeignKeys())
 }
 
 func (s *PackageTransformerSuite) TestApplyInverses_ConfictingCol() {
-	s.t.inverses["foo"] = []*ColumnSchema{
+	s.t.fks["foo"] = []*ColumnSchema{
 		mkCol("foo", TextColumn, false, false, nil),
 	}
 	s.t.tableIndex["foo"] = "foo"
@@ -506,7 +537,7 @@ func (s *PackageTransformerSuite) TestApplyInverses_ConfictingCol() {
 		mkCol("foo", IntegerColumn, false, false, nil),
 	)
 
-	s.Error(s.t.applyInverses())
+	s.Error(s.t.applyForeignKeys())
 }
 
 func (s *PackageTransformerSuite) TestTransform_RepeatedTable() {
@@ -522,7 +553,31 @@ func TestPackageTransformer(t *testing.T) {
 	suite.Run(t, new(PackageTransformerSuite))
 }
 
-func mkModel(tables ...*TableSchema) *DBSchema {
+func TestGraphResolve(t *testing.T) {
+	require := require.New(t)
+	g := newGraph().
+		add("a").
+		add("b").
+		dependsOn("c", "b").
+		dependsOn("d", "c").
+		dependsOn("e", "b").
+		dependsOn("e", "a")
+
+	result, err := g.resolve()
+	require.NoError(err)
+	require.Equal([]string{"e", "a", "d", "c", "b"}, result)
+
+	g = newGraph().
+		add("a").
+		dependsOn("c", "b").
+		dependsOn("a", "c").
+		dependsOn("b", "a")
+
+	_, err = g.resolve()
+	require.Error(err)
+}
+
+func mkSchema(tables ...*TableSchema) *DBSchema {
 	return &DBSchema{tables}
 }
 

--- a/generator/templates/model.tgo
+++ b/generator/templates/model.tgo
@@ -166,6 +166,7 @@ func (s *{{.StoreName}}) inverseRecords(record *{{.Name}}) []kallax.RecordWithSc
 // Insert inserts a {{.Name}} in the database. A non-persisted object is
 // required for this operation.
 func (s *{{.StoreName}}) Insert(record *{{.Name}}) error {
+        {{$.GenTimeTruncations .}}
         {{if .Events.Has "BeforeSave"}}
         if err := record.BeforeSave(); err != nil {
                 return err
@@ -265,6 +266,7 @@ func (s *{{.StoreName}}) Insert(record *{{.Name}}) error {
 // Only writable records can be updated. Writable objects are those that have
 // been just inserted or retrieved using a query with no custom select fields.
 func (s *{{.StoreName}}) Update(record *{{.Name}}, cols ...kallax.SchemaField) (updated int64, err error) {
+        {{$.GenTimeTruncations .}}
         {{if .Events.Has "BeforeSave"}}
         if err := record.BeforeSave(); err != nil {
                 return 0, err

--- a/tests/kallax.go
+++ b/tests/kallax.go
@@ -2430,6 +2430,8 @@ func (s *MultiKeySortFixtureStore) DebugWith(logger kallax.LoggerFunc) *MultiKey
 // Insert inserts a MultiKeySortFixture in the database. A non-persisted object is
 // required for this operation.
 func (s *MultiKeySortFixtureStore) Insert(record *MultiKeySortFixture) error {
+	record.Start = record.Start.Truncate(time.Microsecond)
+	record.End = record.End.Truncate(time.Microsecond)
 
 	return s.Store.Insert(Schema.MultiKeySortFixture.BaseSchema, record)
 
@@ -2442,6 +2444,8 @@ func (s *MultiKeySortFixtureStore) Insert(record *MultiKeySortFixture) error {
 // Only writable records can be updated. Writable objects are those that have
 // been just inserted or retrieved using a query with no custom select fields.
 func (s *MultiKeySortFixtureStore) Update(record *MultiKeySortFixture, cols ...kallax.SchemaField) (updated int64, err error) {
+	record.Start = record.Start.Truncate(time.Microsecond)
+	record.End = record.End.Truncate(time.Microsecond)
 
 	return s.Store.Update(Schema.MultiKeySortFixture.BaseSchema, record, cols...)
 
@@ -2868,6 +2872,9 @@ func (s *NullableStore) DebugWith(logger kallax.LoggerFunc) *NullableStore {
 // Insert inserts a Nullable in the database. A non-persisted object is
 // required for this operation.
 func (s *NullableStore) Insert(record *Nullable) error {
+	if record.T != nil {
+		record.T = func(t time.Time) *time.Time { return &t }(record.T.Truncate(time.Microsecond))
+	}
 
 	return s.Store.Insert(Schema.Nullable.BaseSchema, record)
 
@@ -2880,6 +2887,9 @@ func (s *NullableStore) Insert(record *Nullable) error {
 // Only writable records can be updated. Writable objects are those that have
 // been just inserted or retrieved using a query with no custom select fields.
 func (s *NullableStore) Update(record *Nullable, cols ...kallax.SchemaField) (updated int64, err error) {
+	if record.T != nil {
+		record.T = func(t time.Time) *time.Time { return &t }(record.T.Truncate(time.Microsecond))
+	}
 
 	return s.Store.Update(Schema.Nullable.BaseSchema, record, cols...)
 
@@ -4758,6 +4768,7 @@ func (s *QueryFixtureStore) inverseRecords(record *QueryFixture) []kallax.Record
 // Insert inserts a QueryFixture in the database. A non-persisted object is
 // required for this operation.
 func (s *QueryFixtureStore) Insert(record *QueryFixture) error {
+	record.TimeParam = record.TimeParam.Truncate(time.Microsecond)
 
 	records := s.relationshipRecords(record)
 
@@ -4815,6 +4826,7 @@ func (s *QueryFixtureStore) Insert(record *QueryFixture) error {
 // Only writable records can be updated. Writable objects are those that have
 // been just inserted or retrieved using a query with no custom select fields.
 func (s *QueryFixtureStore) Update(record *QueryFixture, cols ...kallax.SchemaField) (updated int64, err error) {
+	record.TimeParam = record.TimeParam.Truncate(time.Microsecond)
 
 	records := s.relationshipRecords(record)
 


### PR DESCRIPTION
The commands have been split across several files, isolating functionality now, instead of having a single file with everything.

### New commands

- `kallax migrate up --dsn "database source" [--steps N] [--version V] [--all]`
- `kallax migrate down --dsn "database source" [--steps N] [--version V]`

### Bug fixes

- Inverse and non-inverse relationship foreign keys were being swapped.
- Sort `CREATE TABLE`s and `DROP TABLE`s with a dependency graph to ensure it's valid when running the migration. Order of both types of changes is deterministic. So, order of the migration is as follows:
  1. Sorted create tables.
  2. Sorted drop tables.
  3. Rest of the changes, unordered.