### PR TITLE
double -> double precision in schema generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Let's see an example of models with all these cases:
 type User struct {
         kallax.Model       `table:"users"`
         kallax.Timestamps
-        kallax.ID int64    `pk:"autoincr"`
+        ID        int64    `pk:"autoincr"`
         Username  string
         Password  string
         Emails    []string

--- a/generator/migration.go
+++ b/generator/migration.go
@@ -196,7 +196,7 @@ const (
 	IntegerColumn     ColumnType = "integer"
 	BigIntColumn      ColumnType = "bigint"
 	RealColumn        ColumnType = "real"
-	DoubleColumn      ColumnType = "double"
+	DoubleColumn      ColumnType = "double precision"
 	SmallSerialColumn ColumnType = "smallserial"
 	SerialColumn      ColumnType = "serial"
 	BigSerialColumn   ColumnType = "bigserial"


### PR DESCRIPTION
Just last commit, dunno why the other is showing up here

info. https://www.postgresql.org/docs/9.6/static/datatype-numeric.html