### PR TITLE
add manythrough support in queries and batcher, add through props to field

### DIFF
--- a/batcher.go
+++ b/batcher.go
@@ -14,6 +14,7 @@ type batchQueryRunner struct {
 	q             Query
 	oneToOneRels  []Relationship
 	oneToManyRels []Relationship
+	throughRels   []Relationship
 	db            squirrel.DBProxy
 	builder       squirrel.SelectBuilder
 	total         int
@@ -29,6 +30,7 @@ func newBatchQueryRunner(schema Schema, db squirrel.DBProxy, q Query) *batchQuer
 	var (
 		oneToOneRels  []Relationship
 		oneToManyRels []Relationship
+		throughRels   []Relationship
 	)
 
 	for _, rel := range q.getRelationships() {
@@ -37,6 +39,8 @@ func newBatchQueryRunner(schema Schema, db squirrel.DBProxy, q Query) *batchQuer
 			oneToOneRels = append(oneToOneRels, rel)
 		case OneToMany:
 			oneToManyRels = append(oneToManyRels, rel)
+		case Through:
+			throughRels = append(throughRels, rel)
 		}
 	}
 
@@ -46,6 +50,7 @@ func newBatchQueryRunner(schema Schema, db squirrel.DBProxy, q Query) *batchQuer
 		q:             q,
 		oneToOneRels:  oneToOneRels,
 		oneToManyRels: oneToManyRels,
+		throughRels:   throughRels,
 		db:            db,
 		builder:       builder,
 	}
@@ -125,8 +130,14 @@ func (r *batchQueryRunner) processBatch(rows *sql.Rows) ([]Record, error) {
 		return nil, err
 	}
 
+	if len(records) == 0 {
+		return nil, nil
+	}
+
 	var ids = make([]interface{}, len(records))
+	var identType Identifier
 	for i, r := range records {
+		identType = r.GetID()
 		ids[i] = r.GetID().Raw()
 	}
 
@@ -136,22 +147,43 @@ func (r *batchQueryRunner) processBatch(rows *sql.Rows) ([]Record, error) {
 			return nil, err
 		}
 
-		for _, r := range records {
-			err := r.SetRelationship(rel.Field, indexedResults[r.GetID().Raw()])
-			if err != nil {
-				return nil, err
-			}
+		err = setIndexedResults(records, rel, indexedResults)
+		if err != nil {
+			return nil, err
+		}
+	}
 
-			// If the relationship is partial, we can not ensure the results
-			// in the field reflect the truth of the database.
-			// In this case, the parent is marked as non-writable.
-			if rel.Filter != nil {
-				r.setWritable(false)
-			}
+	for _, rel := range r.throughRels {
+		indexedResults, err := r.getRecordThroughRelationships(ids, rel, identType)
+		if err != nil {
+			return nil, err
+		}
+
+		err = setIndexedResults(records, rel, indexedResults)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	return records, nil
+}
+
+func setIndexedResults(records []Record, rel Relationship, indexedResults indexedRecords) error {
+	for _, r := range records {
+		err := r.SetRelationship(rel.Field, indexedResults[r.GetID().Raw()])
+		if err != nil {
+			return err
+		}
+
+		// If the relationship is partial, we can not ensure the results
+		// in the field reflect the truth of the database.
+		// In this case, the parent is marked as non-writable.
+		if rel.Filter != nil {
+			r.setWritable(false)
+		}
+	}
+
+	return nil
 }
 
 type indexedRecords map[interface{}][]Record
@@ -159,40 +191,98 @@ type indexedRecords map[interface{}][]Record
 func (r *batchQueryRunner) getRecordRelationships(ids []interface{}, rel Relationship) (indexedRecords, error) {
 	fk, ok := r.schema.ForeignKey(rel.Field)
 	if !ok {
-		return nil, fmt.Errorf("kallax: cannot find foreign key on field %s for table %s", rel.Field, r.schema.Table())
+		return nil, fmt.Errorf("kallax: cannot find foreign key on field %s of table %s", rel.Field, r.schema.Table())
 	}
 
 	filter := In(fk, ids...)
 	if rel.Filter != nil {
-		And(rel.Filter, filter)
-	} else {
-		rel.Filter = filter
+		filter = And(rel.Filter, filter)
 	}
 
 	q := NewBaseQuery(rel.Schema)
-	q.Where(rel.Filter)
+	q.Where(filter)
 	cols, builder := q.compile()
 	rows, err := builder.RunWith(r.db).Query()
 	if err != nil {
 		return nil, err
 	}
 
+	return indexedResultsFromRows(rows, cols, rel.Schema, fk, nil)
+}
+
+func (r *batchQueryRunner) getRecordThroughRelationships(ids []interface{}, rel Relationship, identType Identifier) (indexedRecords, error) {
+	lfk, rfk, ok := r.schema.ForeignKeys(rel.Field)
+	if !ok {
+		return nil, fmt.Errorf("kallax: cannot find foreign keys for through relationship on field %s of table %s", rel.Field, r.schema.Table())
+	}
+
+	filter := In(r.schema.ID(), ids...)
+	if rel.Filter != nil {
+		filter = And(rel.Filter, filter)
+	}
+
+	if rel.IntermediateFilter != nil {
+		filter = And(rel.IntermediateFilter, filter)
+	}
+
+	q := NewBaseQuery(rel.Schema)
+	lschema := r.schema.WithAlias(rel.Schema.Alias())
+	intSchema := rel.IntermediateSchema.WithAlias(rel.Schema.Alias())
+	q.joinThrough(lschema, intSchema, rel.Schema, lfk, rfk)
+	q.Where(filter)
+	cols, builder := q.compile()
+	// manually add the extra column to also select the parent id
+	builder = builder.Column(lschema.ID().QualifiedName(lschema))
+	rows, err := builder.RunWith(r.db).Query()
+	if err != nil {
+		return nil, err
+	}
+
+	// we need to pass a new pointer of the parent identifier type so the
+	// resultset can fill it and we can know to which record it belongs when
+	// indexing by parent id.
+	return indexedResultsFromRows(rows, cols, rel.Schema, rfk, identType.newPtr())
+}
+
+// indexedResultsFromRows returns the results in the given rows indexed by the
+// parent id. In the case of many to many relationships, the record odes not
+// have a specific field with the ID of the parent to index by it,
+// that's why parentIDPtr is passed for these cases. parentIDPtr is a pointer
+// to an ID of the type required by the parent to be filled by the result set.
+func indexedResultsFromRows(rows *sql.Rows, cols []string, schema Schema, fk SchemaField, parentIDPtr interface{}) (indexedRecords, error) {
 	relRs := NewResultSet(rows, false, nil, cols...)
 	var indexedResults = make(indexedRecords)
 	for relRs.Next() {
-		rec, err := relRs.Get(rel.Schema)
-		if err != nil {
-			return nil, err
+		var (
+			rec Record
+			err error
+		)
+
+		if parentIDPtr != nil {
+			rec, err = relRs.customGet(schema, parentIDPtr)
+		} else {
+			rec, err = relRs.Get(schema)
 		}
 
-		val, err := rec.Value(fk.String())
 		if err != nil {
 			return nil, err
 		}
 
 		rec.setPersisted()
 		rec.setWritable(true)
-		id := val.(Identifier).Raw()
+
+		var id interface{}
+		if parentIDPtr != nil {
+			id = parentIDPtr.(Identifier).Raw()
+		} else {
+			val, err := rec.Value(fk.String())
+			if err != nil {
+				return nil, err
+			}
+
+			id = val.(Identifier).Raw()
+		}
+
 		indexedResults[id] = append(indexedResults[id], rec)
 	}
 

--- a/common_test.go
+++ b/common_test.go
@@ -26,28 +26,49 @@ func openTestDB() (*sql.DB, error) {
 	))
 }
 
-func setupTables(t *testing.T, db *sql.DB) {
-	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS model (
+var tableSchemas = []string{
+	`CREATE TABLE IF NOT EXISTS model (
 		id serial PRIMARY KEY,
 		name varchar(255) not null,
 		email varchar(255) not null,
 		age int not null
-	)`)
-	require.NoError(t, err)
-
-	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS rel (
+	)`,
+	`CREATE TABLE IF NOT EXISTS rel (
 		id serial PRIMARY KEY,
 		model_id integer,
 		foo text
-	)`)
-	require.NoError(t, err)
+	)`,
+	`CREATE TABLE IF NOT EXISTS through_left (
+		id serial PRIMARY KEY,
+		name text not null
+	)`,
+	`CREATE TABLE IF NOT EXISTS through_right (
+		id serial PRIMARY KEY,
+		name text not null
+	)`,
+	`CREATE TABLE IF NOT EXISTS through_middle (
+		id serial PRIMARY KEY,
+		left_id bigint references through_left(id),
+		right_id bigint references through_right(id)
+	)`,
+}
+
+func setupTables(t *testing.T, db *sql.DB) {
+	for _, ts := range tableSchemas {
+		_, err := db.Exec(ts)
+		require.NoError(t, err)
+	}
+}
+
+var tableNames = []string{
+	"rel", "model", "through_middle", "through_left", "through_right",
 }
 
 func teardownTables(t *testing.T, db *sql.DB) {
-	_, err := db.Exec("DROP TABLE model")
-	require.NoError(t, err)
-	_, err = db.Exec("DROP TABLE rel")
-	require.NoError(t, err)
+	for _, tn := range tableNames {
+		_, err := db.Exec(fmt.Sprintf("DROP TABLE %s", tn))
+		require.NoError(t, err)
+	}
 }
 
 type model struct {
@@ -225,9 +246,9 @@ var ModelSchema = NewBaseSchema(
 	"__model",
 	f("id"),
 	ForeignKeys{
-		"rel":     NewForeignKey("model_id", false),
-		"rels":    NewForeignKey("model_id", false),
-		"rel_inv": NewForeignKey("model_id", true),
+		"rel":     []*ForeignKey{NewForeignKey("model_id", false)},
+		"rels":    []*ForeignKey{NewForeignKey("model_id", false)},
+		"rel_inv": []*ForeignKey{NewForeignKey("model_id", true)},
 	},
 	func() Record {
 		return new(model)
@@ -263,6 +284,253 @@ var onlyPkModelSchema = NewBaseSchema(
 	},
 	true,
 	f("id"),
+)
+
+type throughLeft struct {
+	Model
+	ID     int64
+	Name   string
+	Rights []*throughRight
+}
+
+func newThroughLeft(name string) *throughLeft {
+	m := &throughLeft{Model: NewModel(), Name: name}
+	return m
+}
+
+func (m *throughLeft) Value(col string) (interface{}, error) {
+	switch col {
+	case "id":
+		return m.ID, nil
+	case "name":
+		return m.Name, nil
+	}
+	return nil, fmt.Errorf("kallax: column does not exist: %s", col)
+}
+
+func (m *throughLeft) ColumnAddress(col string) (interface{}, error) {
+	switch col {
+	case "id":
+		return &m.ID, nil
+	case "name":
+		return &m.Name, nil
+	}
+	return nil, fmt.Errorf("kallax: column does not exist: %s", col)
+}
+
+func (m *throughLeft) NewRelationshipRecord(field string) (Record, error) {
+	switch field {
+	case "Rights":
+		return new(throughRight), nil
+	}
+	return nil, fmt.Errorf("kallax: no relationship found for field %s", field)
+}
+
+func (m *throughLeft) SetRelationship(field string, record interface{}) error {
+	switch field {
+	case "Rights":
+		rels, ok := record.([]Record)
+		if !ok {
+			return fmt.Errorf("kallax: can't set relationship %s with value of type %T", field, record)
+		}
+		m.Rights = make([]*throughRight, len(rels))
+		for i, r := range rels {
+			rel, ok := r.(*throughRight)
+			if !ok {
+				return fmt.Errorf("kallax: can't set element of relationship %s with element of type %T", field, r)
+			}
+			m.Rights[i] = rel
+		}
+		return nil
+	}
+	return fmt.Errorf("kallax: no relationship found for field %s", field)
+}
+
+func (m *throughLeft) GetID() Identifier {
+	return (*NumericID)(&m.ID)
+}
+
+type throughMiddle struct {
+	Model
+	ID    int64
+	Left  *throughLeft
+	Right *throughRight
+}
+
+func newThroughMiddle(left *throughLeft, right *throughRight) *throughMiddle {
+	m := &throughMiddle{Model: NewModel(), Left: left, Right: right}
+	return m
+}
+
+func (m *throughMiddle) Value(col string) (interface{}, error) {
+	switch col {
+	case "id":
+		return m.ID, nil
+	case "left_id":
+		return m.Left.ID, nil
+	case "right_id":
+		return m.Right.ID, nil
+	}
+	return nil, fmt.Errorf("kallax: column does not exist: %s", col)
+}
+
+func (m *throughMiddle) ColumnAddress(col string) (interface{}, error) {
+	switch col {
+	case "id":
+		return &m.ID, nil
+	}
+	return nil, fmt.Errorf("kallax: column does not exist: %s", col)
+}
+
+func (m *throughMiddle) NewRelationshipRecord(field string) (Record, error) {
+	switch field {
+	case "Left":
+		return new(throughLeft), nil
+	case "Right":
+		return new(throughRight), nil
+	}
+	return nil, fmt.Errorf("kallax: no relationship found for field %s", field)
+}
+
+func (m *throughMiddle) SetRelationship(field string, record interface{}) error {
+	switch field {
+	case "Left":
+		rel, ok := record.(*throughLeft)
+		if !ok {
+			return fmt.Errorf("kallax: can't set relationship %s with a record of type %t", field, record)
+		}
+		m.Left = rel
+		return nil
+	case "Right":
+		rel, ok := record.(*throughRight)
+		if !ok {
+			return fmt.Errorf("kallax: can't set relationship %s with a record of type %t", field, record)
+		}
+		m.Right = rel
+		return nil
+	}
+	return fmt.Errorf("kallax: no relationship found for field %s", field)
+}
+
+func (m *throughMiddle) GetID() Identifier {
+	return (*NumericID)(&m.ID)
+}
+
+type throughRight struct {
+	Model
+	ID    int64
+	Name  string
+	Lefts []*throughLeft
+}
+
+func newThroughRight(name string) *throughRight {
+	m := &throughRight{Model: NewModel(), Name: name}
+	return m
+}
+
+func (m *throughRight) Value(col string) (interface{}, error) {
+	switch col {
+	case "id":
+		return m.ID, nil
+	case "name":
+		return m.Name, nil
+	}
+	return nil, fmt.Errorf("kallax: column does not exist: %s", col)
+}
+
+func (m *throughRight) ColumnAddress(col string) (interface{}, error) {
+	switch col {
+	case "id":
+		return &m.ID, nil
+	case "name":
+		return &m.Name, nil
+	}
+	return nil, fmt.Errorf("kallax: column does not exist: %s", col)
+}
+
+func (m *throughRight) NewRelationshipRecord(field string) (Record, error) {
+	switch field {
+	case "Lefts":
+		return new(throughLeft), nil
+	}
+	return nil, fmt.Errorf("kallax: no relationship found for field %s", field)
+}
+
+func (m *throughRight) SetRelationship(field string, record interface{}) error {
+	switch field {
+	case "Lefts":
+		rels, ok := record.([]Record)
+		if !ok {
+			return fmt.Errorf("kallax: can't set relationship %s with value of type %T", field, record)
+		}
+		m.Lefts = make([]*throughLeft, len(rels))
+		for i, r := range rels {
+			rel, ok := r.(*throughLeft)
+			if !ok {
+				return fmt.Errorf("kallax: can't set element of relationship %s with element of type %T", field, r)
+			}
+			m.Lefts[i] = rel
+		}
+		return nil
+	}
+	return fmt.Errorf("kallax: no relationship found for field %s", field)
+}
+
+func (m *throughRight) GetID() Identifier {
+	return (*NumericID)(&m.ID)
+}
+
+var ThroughLeftSchema = NewBaseSchema(
+	"through_left",
+	"__thleft",
+	f("id"),
+	ForeignKeys{
+		"Rights": []*ForeignKey{
+			NewForeignKey("left_id", false),
+			NewForeignKey("right_id", false),
+		},
+	},
+	func() Record {
+		return new(throughLeft)
+	},
+	true,
+	f("id"),
+	f("name"),
+)
+
+var ThroughMiddleSchema = NewBaseSchema(
+	"through_middle",
+	"__thmiddle",
+	f("id"),
+	ForeignKeys{
+		"Left":  []*ForeignKey{NewForeignKey("left_id", false)},
+		"Right": []*ForeignKey{NewForeignKey("right_id", false)},
+	},
+	func() Record {
+		return new(throughMiddle)
+	},
+	true,
+	f("id"),
+	f("left_id"),
+	f("right_id"),
+)
+
+var ThroughRightSchema = NewBaseSchema(
+	"through_right",
+	"__thright",
+	f("id"),
+	ForeignKeys{
+		"Lefts": []*ForeignKey{
+			NewForeignKey("right_id", false),
+			NewForeignKey("left_id", false),
+		},
+	},
+	func() Record {
+		return new(throughRight)
+	},
+	true,
+	f("id"),
+	f("name"),
 )
 
 func f(name string) SchemaField {

--- a/generator/types.go
+++ b/generator/types.go
@@ -562,6 +562,8 @@ type ImplicitFK struct {
 }
 
 // Field is the representation of a model field.
+// TODO(erizocosmico): please, refactor all this structure to use precomputed
+// data instead of calculating it upon each call.
 type Field struct {
 	// Name is the field name.
 	Name string
@@ -714,8 +716,12 @@ func (f *Field) IsInverse() bool {
 		return false
 	}
 
-	for _, part := range strings.Split(f.Tag.Get("fk"), ",") {
-		if part == "inverse" {
+	if f.IsManyToManyRelationship() {
+		return f.isInverseThrough()
+	}
+
+	for i, part := range strings.Split(f.Tag.Get("fk"), ",") {
+		if i > 0 && part == "inverse" {
 			return true
 		}
 	}
@@ -727,6 +733,58 @@ func (f *Field) IsInverse() bool {
 // relationship.
 func (f *Field) IsOneToManyRelationship() bool {
 	return f.Kind == Relationship && strings.HasPrefix(f.Type, "[]")
+}
+
+// IsManyToManyRelationship reports whether the field is a many to many
+// relationship.
+func (f *Field) IsManyToManyRelationship() bool {
+	return f.Kind == Relationship && f.Tag.Get("through") != ""
+}
+
+// ThroughTable returns the name of the intermediate table used to access the
+// current field.
+func (f *Field) ThroughTable() string {
+	return f.getThroughTablePart(0)
+}
+
+// LeftForeignKey is the name of the column used to join the current model with
+// the intermediate table.
+func (f *Field) LeftForeignKey() string {
+	fk := f.getThroughTablePart(1)
+	if fk == "" {
+		fk = foreignKeyForModel(f.Model.Name)
+	}
+	return fk
+}
+
+// RightForeignKey is the name of the column used to join the relationship
+// model with the intermediate table.
+func (f *Field) RightForeignKey() string {
+	fk := f.getThroughTablePart(2)
+	if fk == "" {
+		fk = foreignKeyForModel(f.TypeSchemaName())
+	}
+	return fk
+}
+
+func (f *Field) isInverseThrough() bool {
+	return f.getThroughPart(1) == "inverse"
+}
+
+func (f *Field) getThroughPart(idx int) string {
+	parts := strings.Split(f.Tag.Get("through"), ",")
+	if len(parts) > idx {
+		return strings.TrimSpace(parts[idx])
+	}
+	return ""
+}
+
+func (f *Field) getThroughTablePart(idx int) string {
+	parts := strings.Split(f.getThroughPart(0), ":")
+	if len(parts) > idx {
+		return strings.TrimSpace(parts[idx])
+	}
+	return ""
 }
 
 func foreignKeyForModel(model string) string {

--- a/generator/types_test.go
+++ b/generator/types_test.go
@@ -194,6 +194,79 @@ func (s *FieldSuite) TestValue() {
 	}
 }
 
+func (s *FieldSuite) TestIsInverse() {
+	cases := []struct {
+		tag      string
+		expected bool
+	}{
+		{"", false},
+		{`inverse:"true"`, false},
+		{`fk:"inverse"`, false},
+		{`through:"inverse"`, false},
+		{`fk:"foo,inverse"`, true},
+		{`fk:",inverse"`, true},
+		{`through:"foo,inverse"`, true},
+		{`through:"foo:a:b,inverse"`, true},
+	}
+
+	for _, tt := range cases {
+		f := withTag(mkField("", ""), tt.tag)
+		f.Kind = Relationship
+		s.Equal(tt.expected, f.IsInverse(), tt.tag)
+	}
+}
+
+func (s *FieldSuite) TestThroughTable() {
+	cases := []struct {
+		tag, expected string
+	}{
+		{``, ""},
+		{`through:"foo"`, "foo"},
+		{`through:"foo,inverse"`, "foo"},
+		{`through:"foo:a:b,inverse"`, "foo"},
+	}
+
+	for _, tt := range cases {
+		s.Equal(tt.expected, withTag(mkField("", ""), tt.tag).ThroughTable(), tt.tag)
+	}
+}
+
+func (s *FieldSuite) TestLeftForeignKey() {
+	cases := []struct {
+		tag, expected string
+	}{
+		{``, "bar_id"},
+		{`through:"foo"`, "bar_id"},
+		{`through:"foo,inverse"`, "bar_id"},
+		{`through:"foo:a,inverse"`, "a"},
+		{`through:"foo:a:b,inverse"`, "a"},
+	}
+
+	for _, tt := range cases {
+		f := withTag(mkField("", ""), tt.tag)
+		f.Model = &Model{Name: "Bar"}
+		s.Equal(tt.expected, f.LeftForeignKey(), tt.tag)
+	}
+}
+
+func (s *FieldSuite) TestRightForeignKey() {
+	cases := []struct {
+		tag, expected string
+	}{
+		{``, "foo_id"},
+		{`through:"foo"`, "foo_id"},
+		{`through:"foo,inverse"`, "foo_id"},
+		{`through:"foo:a,inverse"`, "foo_id"},
+		{`through:"foo:a:b,inverse"`, "b"},
+	}
+
+	for _, tt := range cases {
+		f := withTag(mkField("", ""), tt.tag)
+		f.Type = "Foo"
+		s.Equal(tt.expected, f.RightForeignKey(), tt.tag)
+	}
+}
+
 type ModelSuite struct {
 	suite.Suite
 	model    *Model

--- a/model.go
+++ b/model.go
@@ -113,6 +113,7 @@ type Identifier interface {
 	IsEmpty() bool
 	// Raw returns the internal value of the identifier.
 	Raw() interface{}
+	newPtr() interface{}
 }
 
 // Identifiable must be implemented by those values that can be identified by an ID.
@@ -223,6 +224,10 @@ func NewULIDFromText(text string) (ULID, error) {
 	var id ULID
 	err := id.UnmarshalText([]byte(text))
 	return id, err
+}
+
+func (id ULID) newPtr() interface{} {
+	return new(ULID)
 }
 
 // Scan implements the Scanner interface.
@@ -371,6 +376,10 @@ func (id NumericID) IsEmpty() bool {
 	return int64(id) == 0
 }
 
+func (id NumericID) newPtr() interface{} {
+	return new(NumericID)
+}
+
 // String returns the string representation of the ID.
 func (id NumericID) String() string {
 	return fmt.Sprint(int64(id))
@@ -405,6 +414,10 @@ func (id *UUID) Scan(src interface{}) error {
 // Value implements the Valuer interface.
 func (id UUID) Value() (driver.Value, error) {
 	return uuid.UUID(id).Value()
+}
+
+func (id UUID) newPtr() interface{} {
+	return new(UUID)
 }
 
 // IsEmpty returns whether the ID is empty or not. An empty ID means it has not

--- a/query.go
+++ b/query.go
@@ -7,11 +7,7 @@ import (
 	"github.com/Masterminds/squirrel"
 )
 
-var (
-	// ErrManyToManyNotSupported is returned when a many to many relationship
-	// is added to a query.
-	ErrManyToManyNotSupported = errors.New("kallax: many to many relationships are not supported")
-)
+var ErrThroughNotSupported = errors.New("kallax: a relationship of type Through cannot be added using AddRelation, you need to use AddRelationThrough")
 
 // Query is the common interface all queries must satisfy. The basic abilities
 // of a query are compiling themselves to something executable and return
@@ -164,8 +160,8 @@ func (q *BaseQuery) selectedColumns() []SchemaField {
 // in the given field of the query base schema. A condition to filter can also
 // be passed in the case of one to many relationships.
 func (q *BaseQuery) AddRelation(schema Schema, field string, typ RelationshipType, filter Condition) error {
-	if typ == ManyToMany {
-		return ErrManyToManyNotSupported
+	if typ == Through {
+		return ErrThroughNotSupported
 	}
 
 	fk, ok := q.schema.ForeignKey(field)
@@ -181,8 +177,17 @@ func (q *BaseQuery) AddRelation(schema Schema, field string, typ RelationshipTyp
 		q.join(schema, fk)
 	}
 
-	q.relationships = append(q.relationships, Relationship{typ, field, schema, filter})
+	q.relationships = append(q.relationships, Relationship{typ, field, schema, nil, filter, nil})
 	return nil
+}
+
+// AddRelationThrough adds a relationship through an intermediate table
+// if given to the query, which is present in the given field of the query
+// base schema. Conditions to filter in the intermediate table and the end
+// table can also be passed.
+func (q *BaseQuery) AddRelationThrough(schema, intermediateSchema Schema, field string, intermediateFilter, endFilter Condition) {
+	schema = schema.WithAlias(field)
+	q.relationships = append(q.relationships, Relationship{Through, field, schema, intermediateSchema, endFilter, intermediateFilter})
 }
 
 func (q *BaseQuery) join(schema Schema, fk *ForeignKey) {
@@ -207,6 +212,27 @@ func (q *BaseQuery) join(schema Schema, fk *ForeignKey) {
 			col.QualifiedName(schema),
 		)
 	}
+}
+
+func (q *BaseQuery) joinThrough(lschema, intSchema, rschema Schema, lfk, rfk *ForeignKey) {
+	lfkCol := lfk.QualifiedName(intSchema)
+	rfkCol := rfk.QualifiedName(intSchema)
+	lidCol := lschema.ID().QualifiedName(lschema)
+	ridCol := rschema.ID().QualifiedName(rschema)
+
+	q.builder = q.builder.Join(fmt.Sprintf(
+		"%s %s ON (%s = %s)",
+		intSchema.Table(),
+		intSchema.Alias(),
+		rfkCol,
+		ridCol,
+	)).Join(fmt.Sprintf(
+		"%s %s ON (%s = %s)",
+		lschema.Table(),
+		lschema.Alias(),
+		lfkCol,
+		lidCol,
+	))
 }
 
 // Order adds the given order clauses to the list of columns to order the

--- a/query_test.go
+++ b/query_test.go
@@ -92,9 +92,9 @@ func (s *QuerySuite) TestAddRelation_Inverse() {
 	s.Equal("SELECT __model.id, __model.name, __model.email, __model.age, __rel_rel_inv.id, __rel_rel_inv.model_id, __rel_rel_inv.foo FROM model __model LEFT JOIN rel __rel_rel_inv ON (__rel_rel_inv.id = __model.model_id)", s.q.String())
 }
 
-func (s *QuerySuite) TestAddRelation_ManyToMany() {
-	err := s.q.AddRelation(RelSchema, "rel", ManyToMany, nil)
-	s.Equal(ErrManyToManyNotSupported, err)
+func (s *QuerySuite) TestAddRelation_Through() {
+	err := s.q.AddRelation(RelSchema, "rel", Through, nil)
+	s.Equal(ErrThroughNotSupported, err)
 }
 
 func (s *QuerySuite) TestAddRelation_FKNotFound() {

--- a/resultset.go
+++ b/resultset.go
@@ -51,15 +51,19 @@ func NewResultSet(rows *sql.Rows, readOnly bool, relationships []Relationship, c
 
 // Get returns the next record in the schema.
 func (rs *BaseResultSet) Get(schema Schema) (Record, error) {
+	return rs.customGet(schema)
+}
+
+func (rs *BaseResultSet) customGet(schema Schema, extra ...interface{}) (Record, error) {
 	record := schema.New()
-	if err := rs.Scan(record); err != nil {
+	if err := rs.Scan(record, extra...); err != nil {
 		return nil, err
 	}
 	return record, nil
 }
 
 // Scan fills the column fields of the given value with the current row.
-func (rs *BaseResultSet) Scan(record Record) error {
+func (rs *BaseResultSet) Scan(record Record, extra ...interface{}) error {
 	if len(rs.columns) == 0 {
 		return ErrRawScan
 	}
@@ -95,6 +99,7 @@ func (rs *BaseResultSet) Scan(record Record) error {
 		relationships[i] = rec
 	}
 
+	pointers = append(pointers, extra...)
 	if err := rs.Rows.Scan(pointers...); err != nil {
 		return err
 	}

--- a/store.go
+++ b/store.go
@@ -306,7 +306,8 @@ func (s *Store) RawExec(sql string, params ...interface{}) (int64, error) {
 // Find performs a query and returns a result set with the results.
 func (s *Store) Find(q Query) (ResultSet, error) {
 	rels := q.getRelationships()
-	if containsRelationshipOfType(rels, OneToMany) {
+	if containsRelationshipOfType(rels, OneToMany) ||
+		containsRelationshipOfType(rels, Through) {
 		return NewBatchingResultSet(newBatchQueryRunner(q.Schema(), s.proxy, q)), nil
 	}
 


### PR DESCRIPTION
This PR is the first of several that will be merged into `feature/m2m`, which will be merged when full support for many to many relationships is completely finished.

### What is introduced in this PR?

* Accessing of several properties in `through` struct tag of a field via methods of `Field` type.
* Support both on queries and in the `batchRunner` for retrieving N:M relationships. 1:N using a through _should_ work but that is yet to be tested.

### Notable changes and breaking changes

* `Identifier` now has a `newPtr` method used to get a new fresh empty pointer of that identifier type (internal, just used in the batcher). This restricts the extension of the `Identifier` interface, though, which is probably not a big deal.
* `Scan` now accepts N extra pointers. Again, it's internal and not really exposed to the public, so we should be good.
* `ManyToMany` has been renamed to `Through`, as 1:N with an intermediate table also need to be processed as a `Through` kind of relationship.
* `ForeignKeys` has now a slice of foreign keys, instead of just one. Only generated code uses it, but it will be broken until regeneration.

### What's left?

* [ ] Schema generation
* [ ] Go boilerplate generation
* [ ] Inserts + updates with through relationships
* [ ] Test it works with 1:N with intermediate tables

At least, all the internal mumbo jumbo should be done with this PR.

### Review

I suggest you take a look at it per-commit, as they are very clear and separate functionalities. (Should have made 2 PRs actually, but /shrug)