### PR TITLE
Add unique constraints to columns with `unique:"true"`

### DIFF
--- a/generator/migration.go
+++ b/generator/migration.go
@@ -161,6 +161,8 @@ type ColumnSchema struct {
 	Reference *Reference
 	// NotNull reports whether the column is not nullable.
 	NotNull bool
+	// Unique reports whether the column has a unique constraint
+	Unique bool
 }
 
 func (s *ColumnSchema) Equals(s2 *ColumnSchema) bool {
@@ -168,6 +170,7 @@ func (s *ColumnSchema) Equals(s2 *ColumnSchema) bool {
 		s.Type == s2.Type &&
 		s.PrimaryKey == s2.PrimaryKey &&
 		s.NotNull == s2.NotNull &&
+		s.Unique == s2.Unique &&
 		s.Reference.Equals(s2.Reference)
 }
 
@@ -179,6 +182,10 @@ func (s *ColumnSchema) String() string {
 
 	if s.NotNull {
 		buf.WriteString(" NOT NULL")
+	}
+
+	if s.Unique {
+		buf.WriteString(" UNIQUE")
 	}
 
 	if s.PrimaryKey {
@@ -656,6 +663,13 @@ func ColumnSchemaDiff(table string, old, new *ColumnSchema) ChangeSet {
 		})
 	}
 
+	// TODO: We could actually generate a migration from unique -> not unique but not vice versa!
+	if old.Unique != new.Unique {
+		cs = append(cs, &ManualChange{
+			fmt.Sprintf("don't know how to generate migration for a change of unique/not unique in %s(%s)", table, new.Name),
+		})
+	}
+
 	if referenceChanged(old, new) {
 		cs = append(cs, &ManualChange{
 			fmt.Sprintf("don't know how to generate migration for a change of foreign key in %s(%s)", table, new.Name),
@@ -828,6 +842,7 @@ func (t *packageTransformer) transformField(f *Field) (*ColumnSchema, error) {
 		NotNull:    false,
 		Type:       typ,
 		Reference:  ref,
+		Unique: f.IsUnique(),
 	}, nil
 }
 

--- a/generator/migration_test.go
+++ b/generator/migration_test.go
@@ -609,7 +609,11 @@ func mkTable(name string, columns ...*ColumnSchema) *TableSchema {
 }
 
 func mkCol(name string, typ ColumnType, pk, notNull bool, ref *Reference) *ColumnSchema {
-	return &ColumnSchema{name, typ, pk, ref, notNull}
+	return &ColumnSchema{name, typ, pk, ref, notNull, false}
+}
+
+func mkColUnique(name string, typ ColumnType, pk, notNull bool, ref *Reference) *ColumnSchema {
+	return &ColumnSchema{name, typ, pk, ref, notNull, true}
 }
 
 func mkRef(table, col string, inverse bool) *Reference {

--- a/generator/types.go
+++ b/generator/types.go
@@ -642,6 +642,7 @@ type Field struct {
 
 	primaryKey      string
 	isPrimaryKey    bool
+	isUnique        bool
 	isAutoincrement bool
 	columnName      string
 }
@@ -709,8 +710,22 @@ func NewField(n, t string, tag reflect.StructTag) *Field {
 		primaryKey:      pkName,
 		columnName:      columnName(n, tag),
 		isPrimaryKey:    isPrimaryKey,
+		isUnique:        uniqueProperty(tag),
 		isAutoincrement: autoincr,
 	}
+}
+
+func uniqueProperty(tag reflect.StructTag) bool {
+	val, ok := tag.Lookup("unique")
+	if !ok {
+		return false
+	}
+
+	if val == "" || strings.ToLower(val) == "false" {
+		return false
+	}
+
+	return true
 }
 
 // pkProperties returns the primary key properties from a struct tag.
@@ -794,6 +809,11 @@ func (f *Field) ForeignKey() string {
 // IsPrimaryKey reports whether the field is the primary key.
 func (f *Field) IsPrimaryKey() bool {
 	return f.isPrimaryKey
+}
+
+// IsUnique reports whether the field is unique.
+func (f *Field) IsUnique() bool {
+	return f.isUnique
 }
 
 // IsAutoIncrement reports whether the field is an autoincrementable primary key.

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -431,8 +431,10 @@ func TestNullable(t *testing.T) {
 		if c.isPtr {
 			elem = elem.Elem()
 		}
-		s.Equal(c.nonNullInput, elem.Interface(), c.name)
-
+		// TODO: can be commented in if tests fail locally until fixed.
+		//if c.name != "time.Time" && c.name != "*time.Time" {
+			s.Equal(c.nonNullInput, elem.Interface(), c.name)
+		//}
 		_, err = db.Exec("DROP TABLE foo")
 		s.Nil(err, c.name)
 	}


### PR DESCRIPTION
https://github.com/src-d/go-kallax/issues/171

It's now possible to defined unique constraints for columns. We should discuss the format. Currently it's as proposed in https://github.com/src-d/go-kallax/issues/171

No constraint:
```
`unique:""`
`unique:"false"`
```

With constraint:
```
`unique:"true"`
`unique:"maybe-the-constraint-name-in-future"`
```

Other ideas are:

```
type Foo struct {
    SomeField int `unique:""`
}
```

```
type Foo struct {
    SomeField int `constraint:"unique"`
}
```

Postgres supports the following formats due to https://www.postgresql.org/docs/9.5/static/ddl-constraints.html

```
-- Implemented with this PR
CREATE TABLE products (
    product_no integer UNIQUE,
    name text,
    price numeric
);

-- Not yet supported
CREATE TABLE products (
    product_no integer CONSTRAINT must_be_different UNIQUE,
    name text,
    price numeric
);

-- Not yet supported
CREATE TABLE example (
    a integer,
    b integer,
    c integer,
    UNIQUE (a, c)
);
```

```
CREATE TABLE example (
    a integer,
    b integer,
    c integer,
    UNIQUE (a, c)
);
```