### PR TITLE
fix how relationships are saved

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,8 @@ if err != nil {
 }
 ```
 
-If our model has relationships, they will be saved (**note:** saved as in insert or update) as well. The relationships of the relationships will not, though. Relationships are only saved with one level of depth.
+If our model has relationships, they will be saved, and so will the relationships of the relationships and so on. TL;DR: inserts are recursive.
+**Note:** the relationships will be saved using `Save`, not `Insert`.
 
 ```go
 user := NewUser("foo")
@@ -318,7 +319,8 @@ if err != nil {
 }
 ```
 
-If our model has relationships, they will be saved (**note:** saved as in insert or update) as well. The relationships of the relationships will not, though. Relationships are only saved with one level of depth.
+If our model has relationships, they will be saved, and so will the relationships of the relationships and so on. TL;DR: updates are recursive.
+**Note:** the relationships will be saved using `Save`, not `Update`.
 
 ```go
 user := FindLastPoster()
@@ -345,7 +347,7 @@ if updated {
 }
 ```
 
-If our model has relationships, they will be saved as well. The relationships of the relationships will not, though. Relationships are only saved with one level of depth.
+If our model has relationships, they will be saved, and so will the relationships of the relationships and so on. TL;DR: saves are recursive.
 
 ```go
 user := NewUser("foo")

--- a/generator/template_test.go
+++ b/generator/template_test.go
@@ -141,7 +141,11 @@ return (*types.URL)(r.URL), nil
 case "url_no_ptr":
 return (*types.URL)(&r.UrlNoPtr), nil
 case "rel_id":
-return r.Model.VirtualColumn(col), nil
+v := r.Model.VirtualColumn(col)
+if v == nil {
+return nil, kallax.ErrEmptyVirtualColumn
+}
+return v, nil
 `
 
 func (s *TemplateSuite) TestGenColumnValues() {

--- a/generator/templates/base.tgo
+++ b/generator/templates/base.tgo
@@ -15,5 +15,7 @@ import (
 var _ types.SQLType
 var _ fmt.Formatter
 
+type modelSaveFunc func(*kallax.Store) error
+
 {{template "model" .}}
 {{template "schema" .}}

--- a/generator/templates/model.tgo
+++ b/generator/templates/model.tgo
@@ -119,53 +119,57 @@ func (s *{{.StoreName}}) DebugWith(logger kallax.LoggerFunc) *{{.StoreName}} {
 }
 
 {{if .HasNonInverses}}
-func (s *{{.StoreName}}) relationshipRecords(record *{{.Name}}) []kallax.RecordWithSchema {
-        var records []kallax.RecordWithSchema
+func (s *{{.StoreName}}) relationshipRecords(record *{{.Name}}) []modelSaveFunc {
+        var result []modelSaveFunc
         {{range .NonInverses}}
         {{if .IsOneToManyRelationship}}
         for i := range record.{{.Name}} {
-                record.{{.Name}}[i].ClearVirtualColumns()
-                record.{{.Name}}[i].AddVirtualColumn("{{.ForeignKey}}", record.GetID())
-                records = append(records, kallax.RecordWithSchema{
-                        Schema: Schema.{{.TypeSchemaName}}.BaseSchema,
-                        Record: {{if not ($.IsPtrSlice .)}}&{{end}}record.{{.Name}}[i],
-                })
+                r := {{if not ($.IsPtrSlice .)}}&{{end}}record.{{.Name}}[i]
+                if !r.IsSaving() {
+                        r.AddVirtualColumn("{{.ForeignKey}}", record.GetID())
+                        result = append(result, func(store *kallax.Store) error {
+                                _, err := (&{{.TypeSchemaName}}Store{store}).Save(r)
+                                return err
+                        })
+                }
         }
         {{else}}
-        if {{if .IsPtr}}record.{{.Name}} != nil{{else}}!record.{{.Name}}.GetID().IsEmpty(){{end}} {
-                record.{{.Name}}.ClearVirtualColumns()
-                record.{{.Name}}.AddVirtualColumn("{{.ForeignKey}}", record.GetID())
-                records = append(records, kallax.RecordWithSchema{
-                        Schema: Schema.{{.TypeSchemaName}}.BaseSchema,
-                        Record: {{if not .IsPtr}}&{{end}}record.{{.Name}},
+        if {{if .IsPtr}}record.{{.Name}} != nil{{else}}!record.{{.Name}}.GetID().IsEmpty(){{end}} && !record.{{.Name}}.IsSaving() {
+                r := {{if not .IsPtr}}&{{end}}record.{{.Name}}
+                r.AddVirtualColumn("{{.ForeignKey}}", record.GetID())
+                result = append(result, func(store *kallax.Store) error {
+                        _, err := (&{{.TypeSchemaName}}Store{store}).Save(r)
+                        return err
                 })
         }
         {{end}}
         {{end}}
-        return records
+        return result
 }
 {{end}}
 
 {{if .HasInverses}}
-func (s *{{.StoreName}}) inverseRecords(record *{{.Name}}) []kallax.RecordWithSchema {
-        record.ClearVirtualColumns()
-        var records []kallax.RecordWithSchema
+func (s *{{.StoreName}}) inverseRecords(record *{{.Name}}) []modelSaveFunc {
+        var result []modelSaveFunc
         {{range .Inverses}}
-        if {{if .IsPtr}}record.{{.Name}} != nil{{else}}!record.{{.Name}}.GetID().IsEmpty(){{end}} {
+        if {{if .IsPtr}}record.{{.Name}} != nil{{else}}!record.{{.Name}}.GetID().IsEmpty(){{end}} && !record.{{.Name}}.IsSaving() {
                 record.AddVirtualColumn("{{.ForeignKey}}", record.{{.Name}}.GetID())
-                records = append(records, kallax.RecordWithSchema{
-                        Schema: Schema.{{.TypeSchemaName}}.BaseSchema,
-                        Record: {{if not .IsPtr}}&{{end}}record.{{.Name}},
+                result = append(result, func(store *kallax.Store) error {
+                        _, err := (&{{.TypeSchemaName}}Store{store}).Save(record.{{.Name}})
+                        return err
                 })
         }
         {{end}}
-        return records
+        return result
 }
 {{end}}
 
 // Insert inserts a {{.Name}} in the database. A non-persisted object is
 // required for this operation.
 func (s *{{.StoreName}}) Insert(record *{{.Name}}) error {
+        record.SetSaving(true)
+        defer record.SetSaving(false)
+
         {{$.GenTimeTruncations .}}
         {{if .Events.Has "BeforeSave"}}
         if err := record.BeforeSave(); err != nil {
@@ -183,20 +187,11 @@ func (s *{{.StoreName}}) Insert(record *{{.Name}}) error {
         {{if .HasInverses}}
         inverseRecords := s.inverseRecords(record)
         {{end}}
-        if {{if .HasNonInverses}}len(records) > 0{{end}} {{if and (.HasNonInverses) (.HasInverses)}}&&{{end}} {{if .HasInverses}}len(inverseRecords) > 0{{end}} {
+        if {{if .HasNonInverses}}len(records) > 0{{end}} {{if and (.HasNonInverses) (.HasInverses)}}||{{end}} {{if .HasInverses}}len(inverseRecords) > 0{{end}} {
                 return s.Store.Transaction(func(s *kallax.Store) error {
                         {{if .HasInverses}}
                         for _, r := range inverseRecords {
-                                if err := kallax.ApplyBeforeEvents(r.Record); err != nil {
-                                        return err
-                                }
-                                persisted := r.Record.IsPersisted()
-
-                                if _, err := s.Save(r.Schema, r.Record); err != nil {
-                                        return err
-                                }
-
-                                if err := kallax.ApplyAfterEvents(r.Record, persisted); err != nil {
+                                if err := r(s); err != nil {
                                         return err
                                 }
                         }
@@ -206,16 +201,7 @@ func (s *{{.StoreName}}) Insert(record *{{.Name}}) error {
                         }
                         {{if .HasNonInverses}}
                         for _, r := range records {
-                                if err := kallax.ApplyBeforeEvents(r.Record); err != nil {
-                                        return err
-                                }
-                                persisted := r.Record.IsPersisted()
-
-                                if _, err := s.Save(r.Schema, r.Record); err != nil {
-                                        return err
-                                }
-
-                                if err := kallax.ApplyAfterEvents(r.Record, persisted); err != nil {
+                                if err := r(s); err != nil {
                                         return err
                                 }
                         }
@@ -267,6 +253,9 @@ func (s *{{.StoreName}}) Insert(record *{{.Name}}) error {
 // been just inserted or retrieved using a query with no custom select fields.
 func (s *{{.StoreName}}) Update(record *{{.Name}}, cols ...kallax.SchemaField) (updated int64, err error) {
         {{$.GenTimeTruncations .}}
+
+        record.SetSaving(true)
+        defer record.SetSaving(false)
         {{if .Events.Has "BeforeSave"}}
         if err := record.BeforeSave(); err != nil {
                 return 0, err
@@ -284,20 +273,11 @@ func (s *{{.StoreName}}) Update(record *{{.Name}}, cols ...kallax.SchemaField) (
         {{if .HasInverses}}
         inverseRecords := s.inverseRecords(record)
         {{end}}
-        if {{if .HasNonInverses}}len(records) > 0{{end}} {{if and (.HasNonInverses) (.HasInverses)}}&&{{end}} {{if .HasInverses}}len(inverseRecords) > 0{{end}} {
+        if {{if .HasNonInverses}}len(records) > 0{{end}} {{if and (.HasNonInverses) (.HasInverses)}}||{{end}} {{if .HasInverses}}len(inverseRecords) > 0{{end}} {
                 err = s.Store.Transaction(func(s *kallax.Store) error {
                         {{if .HasInverses}}
                         for _, r := range inverseRecords {
-                                if err := kallax.ApplyBeforeEvents(r.Record); err != nil {
-                                        return err
-                                }
-                                persisted := r.Record.IsPersisted()
-
-                                if _, err := s.Save(r.Schema, r.Record); err != nil {
-                                        return err
-                                }
-
-                                if err := kallax.ApplyAfterEvents(r.Record, persisted); err != nil {
+                                if err := r(s); err != nil {
                                         return err
                                 }
                         }
@@ -310,16 +290,7 @@ func (s *{{.StoreName}}) Update(record *{{.Name}}, cols ...kallax.SchemaField) (
 
                         {{if .HasNonInverses}}
                         for _, r := range records {
-                                if err := kallax.ApplyBeforeEvents(r.Record); err != nil {
-                                        return err
-                                }
-                                persisted := r.Record.IsPersisted()
-
-                                if _, err := s.Save(r.Schema, r.Record); err != nil {
-                                        return err
-                                }
-
-                                if err := kallax.ApplyAfterEvents(r.Record, persisted); err != nil {
+                                if err := r(s); err != nil {
                                         return err
                                 }
                         }

--- a/store.go
+++ b/store.go
@@ -153,7 +153,7 @@ func (s *Store) Insert(schema Schema, record Record) error {
 		return ErrNoColumns
 	}
 
-	values, err := RecordValues(record, cols...)
+	values, cols, err := RecordValues(record, cols...)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func (s *Store) Update(schema Schema, record Record, cols ...SchemaField) (int64
 	}
 
 	columnNames := ColumnNames(cols)
-	values, err := RecordValues(record, columnNames...)
+	values, columnNames, err := RecordValues(record, columnNames...)
 	if err != nil {
 		return 0, err
 	}

--- a/tests/kallax.go
+++ b/tests/kallax.go
@@ -18,6 +18,413 @@ import (
 var _ types.SQLType
 var _ fmt.Formatter
 
+// NewBrand returns a new instance of Brand.
+func NewBrand(name string) (record *Brand) {
+	return newBrand(name)
+}
+
+// GetID returns the primary key of the model.
+func (r *Brand) GetID() kallax.Identifier {
+	return (*kallax.ULID)(&r.ID)
+}
+
+// ColumnAddress returns the pointer to the value of the given column.
+func (r *Brand) ColumnAddress(col string) (interface{}, error) {
+	switch col {
+	case "id":
+		return (*kallax.ULID)(&r.ID), nil
+	case "name":
+		return &r.Name, nil
+
+	default:
+		return nil, fmt.Errorf("kallax: invalid column in Brand: %s", col)
+	}
+}
+
+// Value returns the value of the given column.
+func (r *Brand) Value(col string) (interface{}, error) {
+	switch col {
+	case "id":
+		return r.ID, nil
+	case "name":
+		return r.Name, nil
+
+	default:
+		return nil, fmt.Errorf("kallax: invalid column in Brand: %s", col)
+	}
+}
+
+// NewRelationshipRecord returns a new record for the relatiobship in the given
+// field.
+func (r *Brand) NewRelationshipRecord(field string) (kallax.Record, error) {
+	return nil, fmt.Errorf("kallax: model Brand has no relationships")
+}
+
+// SetRelationship sets the given relationship in the given field.
+func (r *Brand) SetRelationship(field string, rel interface{}) error {
+	return fmt.Errorf("kallax: model Brand has no relationships")
+}
+
+// BrandStore is the entity to access the records of the type Brand
+// in the database.
+type BrandStore struct {
+	*kallax.Store
+}
+
+// NewBrandStore creates a new instance of BrandStore
+// using a SQL database.
+func NewBrandStore(db *sql.DB) *BrandStore {
+	return &BrandStore{kallax.NewStore(db)}
+}
+
+// GenericStore returns the generic store of this store.
+func (s *BrandStore) GenericStore() *kallax.Store {
+	return s.Store
+}
+
+// SetGenericStore changes the generic store of this store.
+func (s *BrandStore) SetGenericStore(store *kallax.Store) {
+	s.Store = store
+}
+
+// Debug returns a new store that will print all SQL statements to stdout using
+// the log.Printf function.
+func (s *BrandStore) Debug() *BrandStore {
+	return &BrandStore{s.Store.Debug()}
+}
+
+// DebugWith returns a new store that will print all SQL statements using the
+// given logger function.
+func (s *BrandStore) DebugWith(logger kallax.LoggerFunc) *BrandStore {
+	return &BrandStore{s.Store.DebugWith(logger)}
+}
+
+// Insert inserts a Brand in the database. A non-persisted object is
+// required for this operation.
+func (s *BrandStore) Insert(record *Brand) error {
+	return s.Store.Insert(Schema.Brand.BaseSchema, record)
+}
+
+// Update updates the given record on the database. If the columns are given,
+// only these columns will be updated. Otherwise all of them will be.
+// Be very careful with this, as you will have a potentially different object
+// in memory but not on the database.
+// Only writable records can be updated. Writable objects are those that have
+// been just inserted or retrieved using a query with no custom select fields.
+func (s *BrandStore) Update(record *Brand, cols ...kallax.SchemaField) (updated int64, err error) {
+	return s.Store.Update(Schema.Brand.BaseSchema, record, cols...)
+}
+
+// Save inserts the object if the record is not persisted, otherwise it updates
+// it. Same rules of Update and Insert apply depending on the case.
+func (s *BrandStore) Save(record *Brand) (updated bool, err error) {
+	if !record.IsPersisted() {
+		return false, s.Insert(record)
+	}
+
+	rowsUpdated, err := s.Update(record)
+	if err != nil {
+		return false, err
+	}
+
+	return rowsUpdated > 0, nil
+}
+
+// Delete removes the given record from the database.
+func (s *BrandStore) Delete(record *Brand) error {
+	return s.Store.Delete(Schema.Brand.BaseSchema, record)
+}
+
+// Find returns the set of results for the given query.
+func (s *BrandStore) Find(q *BrandQuery) (*BrandResultSet, error) {
+	rs, err := s.Store.Find(q)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewBrandResultSet(rs), nil
+}
+
+// MustFind returns the set of results for the given query, but panics if there
+// is any error.
+func (s *BrandStore) MustFind(q *BrandQuery) *BrandResultSet {
+	return NewBrandResultSet(s.Store.MustFind(q))
+}
+
+// Count returns the number of rows that would be retrieved with the given
+// query.
+func (s *BrandStore) Count(q *BrandQuery) (int64, error) {
+	return s.Store.Count(q)
+}
+
+// MustCount returns the number of rows that would be retrieved with the given
+// query, but panics if there is an error.
+func (s *BrandStore) MustCount(q *BrandQuery) int64 {
+	return s.Store.MustCount(q)
+}
+
+// FindOne returns the first row returned by the given query.
+// `ErrNotFound` is returned if there are no results.
+func (s *BrandStore) FindOne(q *BrandQuery) (*Brand, error) {
+	q.Limit(1)
+	q.Offset(0)
+	rs, err := s.Find(q)
+	if err != nil {
+		return nil, err
+	}
+
+	if !rs.Next() {
+		return nil, kallax.ErrNotFound
+	}
+
+	record, err := rs.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := rs.Close(); err != nil {
+		return nil, err
+	}
+
+	return record, nil
+}
+
+// FindAll returns a list of all the rows returned by the given query.
+func (s *BrandStore) FindAll(q *BrandQuery) ([]*Brand, error) {
+	rs, err := s.Find(q)
+	if err != nil {
+		return nil, err
+	}
+
+	return rs.All()
+}
+
+// MustFindOne returns the first row retrieved by the given query. It panics
+// if there is an error or if there are no rows.
+func (s *BrandStore) MustFindOne(q *BrandQuery) *Brand {
+	record, err := s.FindOne(q)
+	if err != nil {
+		panic(err)
+	}
+	return record
+}
+
+// Reload refreshes the Brand with the data in the database and
+// makes it writable.
+func (s *BrandStore) Reload(record *Brand) error {
+	return s.Store.Reload(Schema.Brand.BaseSchema, record)
+}
+
+// Transaction executes the given callback in a transaction and rollbacks if
+// an error is returned.
+// The transaction is only open in the store passed as a parameter to the
+// callback.
+func (s *BrandStore) Transaction(callback func(*BrandStore) error) error {
+	if callback == nil {
+		return kallax.ErrInvalidTxCallback
+	}
+
+	return s.Store.Transaction(func(store *kallax.Store) error {
+		return callback(&BrandStore{store})
+	})
+}
+
+// BrandQuery is the object used to create queries for the Brand
+// entity.
+type BrandQuery struct {
+	*kallax.BaseQuery
+}
+
+// NewBrandQuery returns a new instance of BrandQuery.
+func NewBrandQuery() *BrandQuery {
+	return &BrandQuery{
+		BaseQuery: kallax.NewBaseQuery(Schema.Brand.BaseSchema),
+	}
+}
+
+// Select adds columns to select in the query.
+func (q *BrandQuery) Select(columns ...kallax.SchemaField) *BrandQuery {
+	if len(columns) == 0 {
+		return q
+	}
+	q.BaseQuery.Select(columns...)
+	return q
+}
+
+// SelectNot excludes columns from being selected in the query.
+func (q *BrandQuery) SelectNot(columns ...kallax.SchemaField) *BrandQuery {
+	q.BaseQuery.SelectNot(columns...)
+	return q
+}
+
+// Copy returns a new identical copy of the query. Remember queries are mutable
+// so make a copy any time you need to reuse them.
+func (q *BrandQuery) Copy() *BrandQuery {
+	return &BrandQuery{
+		BaseQuery: q.BaseQuery.Copy(),
+	}
+}
+
+// Order adds order clauses to the query for the given columns.
+func (q *BrandQuery) Order(cols ...kallax.ColumnOrder) *BrandQuery {
+	q.BaseQuery.Order(cols...)
+	return q
+}
+
+// BatchSize sets the number of items to fetch per batch when there are 1:N
+// relationships selected in the query.
+func (q *BrandQuery) BatchSize(size uint64) *BrandQuery {
+	q.BaseQuery.BatchSize(size)
+	return q
+}
+
+// Limit sets the max number of items to retrieve.
+func (q *BrandQuery) Limit(n uint64) *BrandQuery {
+	q.BaseQuery.Limit(n)
+	return q
+}
+
+// Offset sets the number of items to skip from the result set of items.
+func (q *BrandQuery) Offset(n uint64) *BrandQuery {
+	q.BaseQuery.Offset(n)
+	return q
+}
+
+// Where adds a condition to the query. All conditions added are concatenated
+// using a logical AND.
+func (q *BrandQuery) Where(cond kallax.Condition) *BrandQuery {
+	q.BaseQuery.Where(cond)
+	return q
+}
+
+// FindByID adds a new filter to the query that will require that
+// the ID property is equal to one of the passed values; if no passed values,
+// it will do nothing.
+func (q *BrandQuery) FindByID(v ...kallax.ULID) *BrandQuery {
+	if len(v) == 0 {
+		return q
+	}
+	values := make([]interface{}, len(v))
+	for i, val := range v {
+		values[i] = val
+	}
+	return q.Where(kallax.In(Schema.Brand.ID, values...))
+}
+
+// FindByName adds a new filter to the query that will require that
+// the Name property is equal to the passed value.
+func (q *BrandQuery) FindByName(v string) *BrandQuery {
+	return q.Where(kallax.Eq(Schema.Brand.Name, v))
+}
+
+// BrandResultSet is the set of results returned by a query to the
+// database.
+type BrandResultSet struct {
+	ResultSet kallax.ResultSet
+	last      *Brand
+	lastErr   error
+}
+
+// NewBrandResultSet creates a new result set for rows of the type
+// Brand.
+func NewBrandResultSet(rs kallax.ResultSet) *BrandResultSet {
+	return &BrandResultSet{ResultSet: rs}
+}
+
+// Next fetches the next item in the result set and returns true if there is
+// a next item.
+// The result set is closed automatically when there are no more items.
+func (rs *BrandResultSet) Next() bool {
+	if !rs.ResultSet.Next() {
+		rs.lastErr = rs.ResultSet.Close()
+		rs.last = nil
+		return false
+	}
+
+	var record kallax.Record
+	record, rs.lastErr = rs.ResultSet.Get(Schema.Brand.BaseSchema)
+	if rs.lastErr != nil {
+		rs.last = nil
+	} else {
+		var ok bool
+		rs.last, ok = record.(*Brand)
+		if !ok {
+			rs.lastErr = fmt.Errorf("kallax: unable to convert record to *Brand")
+			rs.last = nil
+		}
+	}
+
+	return true
+}
+
+// Get retrieves the last fetched item from the result set and the last error.
+func (rs *BrandResultSet) Get() (*Brand, error) {
+	return rs.last, rs.lastErr
+}
+
+// ForEach iterates over the complete result set passing every record found to
+// the given callback. It is possible to stop the iteration by returning
+// `kallax.ErrStop` in the callback.
+// Result set is always closed at the end.
+func (rs *BrandResultSet) ForEach(fn func(*Brand) error) error {
+	for rs.Next() {
+		record, err := rs.Get()
+		if err != nil {
+			return err
+		}
+
+		if err := fn(record); err != nil {
+			if err == kallax.ErrStop {
+				return rs.Close()
+			}
+
+			return err
+		}
+	}
+	return nil
+}
+
+// All returns all records on the result set and closes the result set.
+func (rs *BrandResultSet) All() ([]*Brand, error) {
+	var result []*Brand
+	for rs.Next() {
+		record, err := rs.Get()
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, record)
+	}
+	return result, nil
+}
+
+// One returns the first record on the result set and closes the result set.
+func (rs *BrandResultSet) One() (*Brand, error) {
+	if !rs.Next() {
+		return nil, kallax.ErrNotFound
+	}
+
+	record, err := rs.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := rs.Close(); err != nil {
+		return nil, err
+	}
+
+	return record, nil
+}
+
+// Err returns the last error occurred.
+func (rs *BrandResultSet) Err() error {
+	return rs.lastErr
+}
+
+// Close closes the result set.
+func (rs *BrandResultSet) Close() error {
+	return rs.ResultSet.Close()
+}
+
 // NewCar returns a new instance of Car.
 func NewCar(model string, owner *Person) (record *Car) {
 	return newCar(model, owner)
@@ -37,6 +444,8 @@ func (r *Car) ColumnAddress(col string) (interface{}, error) {
 		return types.Nullable(kallax.VirtualColumn("owner_id", r, new(kallax.NumericID))), nil
 	case "model_name":
 		return &r.ModelName, nil
+	case "brand_id":
+		return types.Nullable(kallax.VirtualColumn("brand_id", r, new(kallax.ULID))), nil
 
 	default:
 		return nil, fmt.Errorf("kallax: invalid column in Car: %s", col)
@@ -52,6 +461,8 @@ func (r *Car) Value(col string) (interface{}, error) {
 		return r.Model.VirtualColumn(col), nil
 	case "model_name":
 		return r.ModelName, nil
+	case "brand_id":
+		return r.Model.VirtualColumn(col), nil
 
 	default:
 		return nil, fmt.Errorf("kallax: invalid column in Car: %s", col)
@@ -64,6 +475,8 @@ func (r *Car) NewRelationshipRecord(field string) (kallax.Record, error) {
 	switch field {
 	case "Owner":
 		return new(Person), nil
+	case "Brand":
+		return new(Brand), nil
 
 	}
 	return nil, fmt.Errorf("kallax: model Car has no relationship %s", field)
@@ -79,6 +492,16 @@ func (r *Car) SetRelationship(field string, rel interface{}) error {
 		}
 		if !val.GetID().IsEmpty() {
 			r.Owner = val
+		}
+
+		return nil
+	case "Brand":
+		val, ok := rel.(*Brand)
+		if !ok {
+			return fmt.Errorf("kallax: record of type %t can't be assigned to relationship Brand", rel)
+		}
+		if !val.GetID().IsEmpty() {
+			r.Brand = val
 		}
 
 		return nil
@@ -130,6 +553,14 @@ func (s *CarStore) inverseRecords(record *Car) []kallax.RecordWithSchema {
 		records = append(records, kallax.RecordWithSchema{
 			Schema: Schema.Person.BaseSchema,
 			Record: record.Owner,
+		})
+	}
+
+	if record.Brand != nil {
+		record.AddVirtualColumn("brand_id", record.Brand.GetID())
+		records = append(records, kallax.RecordWithSchema{
+			Schema: Schema.Brand.BaseSchema,
+			Record: record.Brand,
 		})
 	}
 
@@ -452,6 +883,11 @@ func (q *CarQuery) WithOwner() *CarQuery {
 	return q
 }
 
+func (q *CarQuery) WithBrand() *CarQuery {
+	q.AddRelation(Schema.Brand.BaseSchema, "Brand", kallax.OneToOne, nil)
+	return q
+}
+
 // FindByID adds a new filter to the query that will require that
 // the ID property is equal to one of the passed values; if no passed values,
 // it will do nothing.
@@ -476,6 +912,12 @@ func (q *CarQuery) FindByOwner(v int64) *CarQuery {
 // the ModelName property is equal to the passed value.
 func (q *CarQuery) FindByModelName(v string) *CarQuery {
 	return q.Where(kallax.Eq(Schema.Car.ModelName, v))
+}
+
+// FindByBrand adds a new filter to the query that will require that
+// the foreign key of Brand is equal to the passed value.
+func (q *CarQuery) FindByBrand(v kallax.ULID) *CarQuery {
+	return q.Where(kallax.Eq(Schema.Car.BrandFK, v))
 }
 
 // CarResultSet is the set of results returned by a query to the
@@ -10392,6 +10834,7 @@ func (rs *StoreWithNewFixtureResultSet) Close() error {
 }
 
 type schema struct {
+	Brand                     *schemaBrand
 	Car                       *schemaCar
 	Child                     *schemaChild
 	EventsAllFixture          *schemaEventsAllFixture
@@ -10414,11 +10857,18 @@ type schema struct {
 	StoreWithNewFixture       *schemaStoreWithNewFixture
 }
 
+type schemaBrand struct {
+	*kallax.BaseSchema
+	ID   kallax.SchemaField
+	Name kallax.SchemaField
+}
+
 type schemaCar struct {
 	*kallax.BaseSchema
 	ID        kallax.SchemaField
 	OwnerFK   kallax.SchemaField
 	ModelName kallax.SchemaField
+	BrandFK   kallax.SchemaField
 }
 
 type schemaChild struct {
@@ -10627,6 +11077,22 @@ type schemaNullableSomeJSON struct {
 }
 
 var Schema = &schema{
+	Brand: &schemaBrand{
+		BaseSchema: kallax.NewBaseSchema(
+			"brands",
+			"__brand",
+			kallax.NewSchemaField("id"),
+			kallax.ForeignKeys{},
+			func() kallax.Record {
+				return new(Brand)
+			},
+			false,
+			kallax.NewSchemaField("id"),
+			kallax.NewSchemaField("name"),
+		),
+		ID:   kallax.NewSchemaField("id"),
+		Name: kallax.NewSchemaField("name"),
+	},
 	Car: &schemaCar{
 		BaseSchema: kallax.NewBaseSchema(
 			"cars",
@@ -10634,6 +11100,7 @@ var Schema = &schema{
 			kallax.NewSchemaField("id"),
 			kallax.ForeignKeys{
 				"Owner": kallax.NewForeignKey("owner_id", true),
+				"Brand": kallax.NewForeignKey("brand_id", true),
 			},
 			func() kallax.Record {
 				return new(Car)
@@ -10642,10 +11109,12 @@ var Schema = &schema{
 			kallax.NewSchemaField("id"),
 			kallax.NewSchemaField("owner_id"),
 			kallax.NewSchemaField("model_name"),
+			kallax.NewSchemaField("brand_id"),
 		),
 		ID:        kallax.NewSchemaField("id"),
 		OwnerFK:   kallax.NewSchemaField("owner_id"),
 		ModelName: kallax.NewSchemaField("model_name"),
+		BrandFK:   kallax.NewSchemaField("brand_id"),
 	},
 	Child: &schemaChild{
 		BaseSchema: kallax.NewBaseSchema(

--- a/tests/relationships.go
+++ b/tests/relationships.go
@@ -7,7 +7,14 @@ type Car struct {
 	ID           kallax.ULID `pk:""`
 	Owner        *Person     `fk:"owner_id,inverse"`
 	ModelName    string
+	Brand        *Brand `fk:"brand_id,inverse"`
 	events       map[string]int
+}
+
+type Brand struct {
+	kallax.Model `table:"brands"`
+	ID           kallax.ULID `pk:""`
+	Name         string
 }
 
 func (c *Car) ensureMapInitialized() {
@@ -133,4 +140,14 @@ func newCar(model string, owner *Person) *Car {
 	car := &Car{ID: kallax.NewULID(), ModelName: model, Owner: owner}
 	owner.Car = car
 	return car
+}
+
+func newBrandedCar(model string, owner *Person, brand *Brand) *Car {
+	car := &Car{ID: kallax.NewULID(), ModelName: model, Owner: owner, Brand: brand}
+	owner.Car = car
+	return car
+}
+
+func newBrand(name string) *Brand {
+	return &Brand{Name: name, ID: kallax.NewULID()}
 }

--- a/tests/store.go
+++ b/tests/store.go
@@ -6,6 +6,44 @@ import (
 	"gopkg.in/src-d/go-kallax.v1"
 )
 
+type A struct {
+	kallax.Model `table:"a" pk:"id,autoincr"`
+	ID           int64
+	Name         string
+	B            *B
+}
+
+func newA(name string) *A {
+	return &A{Name: name}
+}
+
+type B struct {
+	kallax.Model `table:"b" pk:"id,autoincr"`
+	ID           int64
+	Name         string
+	A            *A `fk:",inverse"`
+	C            *C
+}
+
+func newB(name string, a *A) *B {
+	b := &B{Name: name, A: a}
+	a.B = b
+	return b
+}
+
+type C struct {
+	kallax.Model `table:"c" pk:"id,autoincr"`
+	ID           int64
+	Name         string
+	B            *B `fk:",inverse"`
+}
+
+func newC(name string, b *B) *C {
+	c := &C{Name: name, B: b}
+	b.C = c
+	return c
+}
+
 type AliasSliceString []string
 
 type StoreFixture struct {


### PR DESCRIPTION
Fixes #211 

There has been a major change here:
- Recursive saves (even with circular dependencies) are now supported!
- `Model` interface has changed, but it's not considered public API, so will not trigger a major version bump.

And also a bug has been fixed as a result:
- If the virtual column corresponding to a relationship foreign key is empty (because, for example, the relationship has not been retrieved in the query) but exists in the database, now it is ignored. Before it was deleted without checking if it existed in the database. This does not break any expected behavior because relationships should not be removed by just removing them from the object but using the Remove* methods from the store. All this behavior is now heavily tested.

Thanks to @roobre for reporting this and adding the reproduction case.