### PR TITLE
improve memory footprint and performance of updates

### DIFF
--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -118,6 +118,23 @@ func BenchmarkKallaxInsertWithRelationships(b *testing.B) {
 	}
 }
 
+func BenchmarkKallaxUpdateWithRelationships(b *testing.B) {
+	db := setupDB(b, openTestDB(b))
+	defer teardownDB(b, db)
+
+	store := NewPersonStore(db)
+	pers := mkPersonWithRels()
+	if err := store.Insert(pers); err != nil {
+		b.Fatalf("error inserting: %s", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		if _, err := store.Update(pers); err != nil {
+			b.Fatalf("error updating: %s", err)
+		}
+	}
+}
+
 func BenchmarkSQLBoilerInsertWithRelationships(b *testing.B) {
 	db := setupDB(b, openTestDB(b))
 	defer teardownDB(b, db)
@@ -189,6 +206,23 @@ func BenchmarkKallaxInsert(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		if err := store.Insert(&Person{Name: "foo"}); err != nil {
 			b.Fatalf("error inserting: %s", err)
+		}
+	}
+}
+
+func BenchmarkKallaxUpdate(b *testing.B) {
+	db := setupDB(b, openTestDB(b))
+	defer teardownDB(b, db)
+
+	store := NewPersonStore(db)
+	pers := &Person{Name: "foo"}
+	if err := store.Insert(pers); err != nil {
+		b.Fatalf("error inserting: %s", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		if _, err := store.Update(pers); err != nil {
+			b.Fatalf("error updating: %s", err)
 		}
 	}
 }


### PR DESCRIPTION
Depends on #214 and #216, just review last commit

Another dramatic cut in memory usage. This one's even higher:

```
BenchmarkKallaxUpdateWithRelationships-4   	     200	   6084449 ns/op	   25921 B/op	     570 allocs/op
BenchmarkKallaxUpdate-4                    	     300	   4169555 ns/op	    4201 B/op	     102 allocs/op
```

```
BenchmarkKallaxUpdateWithRelationships-4   	     200	   5436011 ns/op	    6643 B/op	     175 allocs/op
BenchmarkKallaxUpdate-4                    	     300	   4010681 ns/op	     656 B/op	      25 allocs/op
```