### PR TITLE
Added test case for #230

### DIFF
--- a/tests/relationships_test.go
+++ b/tests/relationships_test.go
@@ -132,6 +132,39 @@ func (s *RelationshipsSuite) TestSaveWithInverse() {
 	s.NotNil(s.getPerson())
 }
 
+func (s *RelationshipsSuite) TestInsertWithInverseZeroId() {
+	p := &Person{Name: "Foo"}
+	car := &Car{ModelName: "Bar"}
+
+	car.Owner = p
+
+	store := NewCarStore(s.db)
+	s.NoError(store.Insert(car))
+
+	car, err := store.FindOne(NewCarQuery().FindByID(car.ID).WithOwner())
+	s.NoError(err)
+	s.NotNil(car.Owner)
+}
+
+
+func (s *RelationshipsSuite) TestSaveWithInverseZeroId() {
+	p := &Person{Name: "Foo"}
+	car := &Car{ModelName: "Bar"}
+
+	store := NewCarStore(s.db)
+	s.NoError(store.Insert(car))
+
+	car, err := store.FindOne(NewCarQuery().FindByID(car.ID))
+	s.NoError(err)
+
+	car.Owner = p
+	store.Save(car)
+
+	car, err = store.FindOne(NewCarQuery().FindByID(car.ID).WithOwner())
+	s.NoError(err)
+	s.NotNil(car.Owner)
+}
+
 func (s *RelationshipsSuite) TestSaveRelations() {
 	p := NewPerson("Musk")
 	brand := newBrand("Tesla")


### PR DESCRIPTION
Added test case for #230

`Save()` behaves incorrectly if a new model with zeroed ID is appended, inserting zeroed IDs instead of falling back to auto-increment like `Insert()` does