### PR TITLE
Add debugEnabled flag to Store to persist debug logging in transactions

### DIFF
--- a/store_test.go
+++ b/store_test.go
@@ -321,6 +321,21 @@ func (s *StoreSuite) TestTransaction() {
 	s.assertCount(2)
 }
 
+func (s *StoreSuite) TestTransaction_FromDebugStore() {
+	debugStore := s.store.Debug()
+	s.Equal(true, debugStore.debugEnabled)
+	transactionDebuggingEnabled := false
+	err := debugStore.Transaction(func(store *Store) error {
+		transactionDebuggingEnabled = store.debugEnabled
+
+		return store.Transaction(func(store *Store) error {
+			return store.Insert(ModelSchema, newModel("Anna", "", 1))
+		})
+	})
+	s.NoError(err)
+	s.Equal(true, transactionDebuggingEnabled)
+}
+
 func (s *StoreSuite) TestTransaction_CantOpen() {
 	err := s.errStore.Transaction(func(store *Store) error {
 		return nil


### PR DESCRIPTION
Took a crack at fixing #254 . Let me know what you think.

P.S. I'm not in love with the name `debugEnabled`, but I think it's better than `debug`. Maybe `debugLogging` or `usesDebugLogging`? I don't know. I'm terrible at naming things. Any preference @roobre ?