### PR TITLE
fix NewULID for systems with low time resolution

### DIFF
--- a/model.go
+++ b/model.go
@@ -229,7 +229,8 @@ type Record interface {
 
 var randPool = &sync.Pool{
 	New: func() interface{} {
-		return rand.NewSource(time.Now().UnixNano())
+		seed := time.Now().UnixNano() + rand.Int63()
+		return rand.NewSource(seed)
 	},
 }
 


### PR DESCRIPTION
NewULID uses a pool of rand.Source using time.Now() as seed. In some systems with high concurrency and lower time resolution, this leads to multiple sources with the same seed, making NewULID return equal values on subsequent calls.
    
This commit changes the seed to add a random number from the global shared rand.Source (which is thread-safe).