### PR TITLE
Use crypto/rand entropy source for ulid.New

### DIFF
--- a/model.go
+++ b/model.go
@@ -2,6 +2,7 @@ package kallax
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"database/sql"
 	"database/sql/driver"
 	"encoding/hex"
@@ -229,7 +230,14 @@ type Record interface {
 
 var randPool = &sync.Pool{
 	New: func() interface{} {
-		seed := time.Now().UnixNano() + rand.Int63()
+		var seedbuffer [8]byte
+		crand.Read(seedbuffer[:])
+
+		var seed int64
+		for i, seedbyte := range seedbuffer {
+			seed |= int64(seedbyte) << uint8(8*i)
+		}
+
 		return rand.NewSource(seed)
 	},
 }

--- a/model.go
+++ b/model.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"encoding/binary"
 	"github.com/oklog/ulid"
 	uuid "github.com/satori/go.uuid"
 )
@@ -230,12 +231,10 @@ type Record interface {
 
 var randPool = &sync.Pool{
 	New: func() interface{} {
-		var seedbuffer [8]byte
-		crand.Read(seedbuffer[:])
-
 		var seed int64
-		for i, seedbyte := range seedbuffer {
-			seed |= int64(seedbyte) << uint8(8*i)
+		err := binary.Read(crand.Reader, binary.LittleEndian, &seed)
+		if err != nil {
+			panic(err)
 		}
 
 		return rand.NewSource(seed)

--- a/model.go
+++ b/model.go
@@ -2,16 +2,13 @@ package kallax
 
 import (
 	"bytes"
-	crand "crypto/rand"
+	"crypto/rand"
 	"database/sql"
 	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
-	"math/rand"
-	"sync"
 	"time"
 
-	"encoding/binary"
 	"github.com/oklog/ulid"
 	uuid "github.com/satori/go.uuid"
 )
@@ -229,18 +226,6 @@ type Record interface {
 	Saveable
 }
 
-var randPool = &sync.Pool{
-	New: func() interface{} {
-		var seed int64
-		err := binary.Read(crand.Reader, binary.LittleEndian, &seed)
-		if err != nil {
-			panic(err)
-		}
-
-		return rand.NewSource(seed)
-	},
-}
-
 // ULID is an ID type provided by kallax that is a lexically sortable UUID.
 // The internal representation is an ULID (https://github.com/oklog/ulid).
 // It already implements sql.Scanner and driver.Valuer, so it's perfectly
@@ -249,11 +234,7 @@ type ULID uuid.UUID
 
 // NewULID returns a new ULID, which is a lexically sortable UUID.
 func NewULID() ULID {
-	entropy := randPool.Get().(rand.Source)
-	id := ULID(ulid.MustNew(ulid.Timestamp(time.Now()), rand.New(entropy)))
-	randPool.Put(entropy)
-
-	return id
+	return ULID(ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader))
 }
 
 // NewULIDFromText creates a new ULID from its string representation. Will


### PR DESCRIPTION
This is perhaps a better solution than seeding rand with current time.

At first, I considered replacing `math/rand` with `crypto/rand` completely. However, the latter is quite slower than the first, taking near to 1ms per random number retrieved. I don't personally think this is something relevant, but just in case I used this approach instead, where `math/rand` is used but seeded with truly random data from `crypto/rand`.

I'd like your opinion about this. Tests pass and benchmarks report quite identical results:

`devel` branch:

```
[roobre@Archiroo]% ~/.local/go/src/gopkg.in/src-d/go-kallax.v1/benchmarks> go test -bench=. -benchmem

goos: linux
goarch: amd64
pkg: gopkg.in/src-d/go-kallax.v1/benchmarks
BenchmarkKallaxInsertWithRelationships-4             200       8710034 ns/op       11148 B/op        226 allocs/op
BenchmarkKallaxUpdateWithRelationships-4             200       7429408 ns/op        7882 B/op        194 allocs/op
BenchmarkSQLBoilerInsertWithRelationships-4          200       9277989 ns/op        7477 B/op        215 allocs/op
BenchmarkRawSQLInsertWithRelationships-4             200       9239012 ns/op        5919 B/op        153 allocs/op
BenchmarkGORMInsertWithRelationships-4               200       6689016 ns/op       38158 B/op        646 allocs/op
BenchmarkKallaxInsert-4                              300       4944226 ns/op        1348 B/op         31 allocs/op
BenchmarkKallaxUpdate-4                              200       5295909 ns/op         939 B/op         30 allocs/op
BenchmarkSQLBoilerInsert-4                           200       5752364 ns/op        1399 B/op         40 allocs/op
BenchmarkRawSQLInsert-4                              200       5560605 ns/op        1337 B/op         33 allocs/op
BenchmarkGORMInsert-4                                200       9160774 ns/op        4346 B/op         99 allocs/op
BenchmarkKallaxQueryRelationships/query-4           1000       1575573 ns/op      273729 B/op       6217 allocs/op
BenchmarkSQLBoilerQueryRelationships/query-4        2000        877351 ns/op      129145 B/op       4614 allocs/op
BenchmarkRawSQLQueryRelationships/query-4             50      31560875 ns/op      348867 B/op      12429 allocs/op
BenchmarkGORMQueryRelationships/query-4             1000       2022755 ns/op      840629 B/op      19271 allocs/op
BenchmarkKallaxQuery/query-4                        3000        451538 ns/op       50885 B/op       1594 allocs/op
BenchmarkSQLBoilerQuery/query-4                     5000        380487 ns/op       54358 B/op       2342 allocs/op
BenchmarkRawSQLQuery/query-4                        5000        277196 ns/op       37755 B/op       1530 allocs/op
BenchmarkGORMQuery/query-4                          2000        650152 ns/op      337674 B/op       6274 allocs/op
PASS
ok      gopkg.in/src-d/go-kallax.v1/benchmarks  58.765s
```

`santalla/devel` branch:
```
[roobre@Archiroo]% ~/.local/go/src/gopkg.in/src-d/go-kallax.v1/benchmarks> go test -bench=. -benchmem

goos: linux
goarch: amd64
pkg: gopkg.in/src-d/go-kallax.v1/benchmarks
BenchmarkKallaxInsertWithRelationships-4             200       9209112 ns/op       11051 B/op        226 allocs/op
BenchmarkKallaxUpdateWithRelationships-4             200       8729955 ns/op        7916 B/op        195 allocs/op
BenchmarkSQLBoilerInsertWithRelationships-4          200       8780699 ns/op        7426 B/op        215 allocs/op
BenchmarkRawSQLInsertWithRelationships-4             200       7637796 ns/op        5918 B/op        153 allocs/op
BenchmarkGORMInsertWithRelationships-4               200       7156625 ns/op       38217 B/op        646 allocs/op
BenchmarkKallaxInsert-4                              200       5291011 ns/op        1389 B/op         32 allocs/op
BenchmarkKallaxUpdate-4                              300       5135029 ns/op         896 B/op         30 allocs/op
BenchmarkSQLBoilerInsert-4                           200       7293355 ns/op        1400 B/op         40 allocs/op
BenchmarkRawSQLInsert-4                              200       5276746 ns/op        1310 B/op         33 allocs/op
BenchmarkGORMInsert-4                                100      11654253 ns/op        4435 B/op        100 allocs/op
BenchmarkKallaxQueryRelationships/query-4           1000       1689769 ns/op      273720 B/op       6217 allocs/op
BenchmarkSQLBoilerQueryRelationships/query-4        1000       1021805 ns/op      129152 B/op       4614 allocs/op
BenchmarkRawSQLQueryRelationships/query-4             50      32662657 ns/op      348863 B/op      12429 allocs/op
BenchmarkGORMQueryRelationships/query-4              500       2075819 ns/op      840609 B/op      19271 allocs/op
BenchmarkKallaxQuery/query-4                        5000        293686 ns/op       50884 B/op       1594 allocs/op
BenchmarkSQLBoilerQuery/query-4                     5000        386639 ns/op       54357 B/op       2342 allocs/op
BenchmarkRawSQLQuery/query-4                        5000        282941 ns/op       37754 B/op       1530 allocs/op
BenchmarkGORMQuery/query-4                          2000        643980 ns/op      337671 B/op       6274 allocs/op
PASS
ok      gopkg.in/src-d/go-kallax.v1/benchmarks  58.230s
```