### PR TITLE
test: use DBHOST while running tests

### DIFF
--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -22,9 +22,10 @@ func envOrDefault(key string, def string) string {
 
 func dbURL() string {
 	return fmt.Sprintf(
-		"postgres://%s:%s@0.0.0.0:5432/%s?sslmode=disable",
+		"postgres://%s:%s@%s/%s?sslmode=disable",
 		envOrDefault("DBUSER", "testing"),
 		envOrDefault("DBPASS", "testing"),
+		envOrDefault("DBHOST", "0.0.0.0:5432"),
 		envOrDefault("DBNAME", "testing"),
 	)
 }

--- a/common_test.go
+++ b/common_test.go
@@ -19,9 +19,10 @@ func envOrDefault(key string, def string) string {
 
 func openTestDB() (*sql.DB, error) {
 	return sql.Open("postgres", fmt.Sprintf(
-		"postgres://%s:%s@0.0.0.0:5432/%s?sslmode=disable",
+		"postgres://%s:%s@%s/%s?sslmode=disable",
 		envOrDefault("DBUSER", "testing"),
 		envOrDefault("DBPASS", "testing"),
+		envOrDefault("DBHOST", "0.0.0.0:5432"),
 		envOrDefault("DBNAME", "testing"),
 	))
 }

--- a/types/slices_test.go
+++ b/types/slices_test.go
@@ -217,9 +217,10 @@ func envOrDefault(key string, def string) string {
 
 func openTestDB() (*sql.DB, error) {
 	return sql.Open("postgres", fmt.Sprintf(
-		"postgres://%s:%s@0.0.0.0:5432/%s?sslmode=disable",
+		"postgres://%s:%s@%s/%s?sslmode=disable",
 		envOrDefault("DBUSER", "testing"),
 		envOrDefault("DBPASS", "testing"),
+		envOrDefault("DBHOST", "0.0.0.0:5432"),
 		envOrDefault("DBNAME", "testing"),
 	))
 }


### PR DESCRIPTION
This allows us to run tests against a PostgreSQL instance on a different host or a non-default port.
