### PR TITLE
Use 'SELECT *' when running basic select queries

### DIFF
--- a/query.go
+++ b/query.go
@@ -261,6 +261,12 @@ func (q *BaseQuery) Where(cond Condition) {
 
 // compile returns the selected column names and the select builder.
 func (q *BaseQuery) compile() ([]string, squirrel.SelectBuilder) {
+	// If we have no explicitly selected columns, and no relation columns,
+	// then we can skip compiling column names.
+	if len(q.relationships) == 0 && !q.selectChanged {
+		return nil, q.builder.Columns("*")
+	}
+
 	columns := q.selectedColumns()
 	var (
 		qualifiedColumns = make([]string, len(columns))

--- a/resultset.go
+++ b/resultset.go
@@ -60,6 +60,18 @@ func (rs *BaseResultSet) Get(schema Schema) (Record, error) {
 
 // Scan fills the column fields of the given value with the current row.
 func (rs *BaseResultSet) Scan(record Record) error {
+	// If the query did not set columns, then we MUST use the columns defined by
+	// the RowDescription response.
+	if len(rs.columns) == 0 {
+		columns, err := rs.Rows.Columns()
+		if err != nil {
+			return err
+		}
+		rs.columns = columns
+	}
+
+	// Now if the columns are still empty, then the database did not inform
+	// us so we can't scan.
 	if len(rs.columns) == 0 {
 		return ErrRawScan
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -164,7 +164,7 @@ func (s *StoreSuite) TestRawQuery() {
 	var names []string
 	for rs.Next() {
 		_, err := rs.Get(ModelSchema)
-		s.Equal(ErrRawScan, err)
+		s.NoError(err)
 		var name string
 		s.NoError(rs.RawScan(&name))
 		names = append(names, name)


### PR DESCRIPTION
This is a really simple cut at moving simple `select` queries over to `select *`. Right now it makes very few assumptions, but can reduce the number of bytes sent over the wire quite significantly. For us it's ~10x fewer bytes. Obviously responses are still going to be large in those cases, so it's not a :tada: great performance boost, but it does help our developer UX.

#### What promoted me to look into this?

We use kallax in an app that supports a legacy app. They share the same DB, but we serve some of the slower code paths using a server written in go + kallax. We love this setup! Kallax rocks!

We have some checks in place to make sure DB schema changes remain in sync for both projects. For example: when the legacy app adds a column to the DB, but the kallax schema has not been regenerated yet. Normally this isn't an issue because a new column can be added to the legacy app and run just fine until our kallax schema is updated. Queries will continue to work for both apps. However, we recently encountered a flow where the legacy code dropped a database column that had been ignored for years, but, since the kallax schema still had a reference to it, the DB queries started returning errors due to the fact that kallax provides an explicit list of columns to the select builder.
```
select a, b, c, d, ...
```
To work around this edge case, we added checks on our side, but I couldn't help wanting to take a crack at using `select *` when it made sense in kallax. All of our other apps and ORMs (ruby, elixir, c++ and python) all use `select *`, so finding a way to bring kallax closer to our existing conventions (even as an opt-in configuration), would certainly be a win for our team.

#### How does this work?

When the query is compiled, it checks to see if it has any relationships or if the selected columns have changed (a custom select: `query.Select(schema.Persona.Name)`). If both have not been touched, then will be used `*` instead.

Then, when `ResultSet.Scan` is called with no columns, it will fallback to the `sql.Rows.Columns` method, which will contain the rows as defined by the `RowDescription` message from postgres. Why? Because the order of columns in the database will be different from the order of columns in the kallax schema. To avoid mismatched types, we must fallback to the db's response.

NOTE: One benefit here is that we can probably remove the `RawScan` method, since the `Scan` method will now fallback to columns of the `sql.Rows` itself.