### PR TITLE
use golang-migrate/migrate instead of mattes/migrate

### DIFF
--- a/generator/cli/kallax/cmd/migrate.go
+++ b/generator/cli/kallax/cmd/migrate.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/mattes/migrate"
-	_ "github.com/mattes/migrate/database/postgres"
-	_ "github.com/mattes/migrate/source/file"
+	"github.com/golang-migrate/migrate"
+	_ "github.com/golang-migrate/migrate/database/postgres"
+	_ "github.com/golang-migrate/migrate/source/file"
 
 	"gopkg.in/src-d/go-kallax.v1/generator"
 	cli "gopkg.in/urfave/cli.v1"


### PR DESCRIPTION
https://github.com/mattes/migrate is deprecated.

But there is a fork https://github.com/golang-migrate/migrate which has some improvements related to postgres:
- https://github.com/golang-migrate/migrate/pull/4
- https://github.com/golang-migrate/migrate/pull/13
- https://github.com/golang-migrate/migrate/pull/71