### PR TITLE
Select star without schema alias in count

### DIFF
--- a/store.go
+++ b/store.go
@@ -439,13 +439,11 @@ func (s *Store) Reload(schema Schema, record Record) error {
 	return rs.Scan(record)
 }
 
-var all = NewSchemaField("*")
-
 // Count returns the number of rows selected by the given query.
 func (s *Store) Count(q Query) (count int64, err error) {
 	_, queryBuilder := q.compile()
 	builder := builder.Set(queryBuilder, "Columns", nil).(squirrel.SelectBuilder)
-	err = builder.Column(fmt.Sprintf("COUNT(%s)", all.QualifiedName(q.Schema()))).
+	err = builder.Column("COUNT(*)").
 		RunWith(s.runner).
 		QueryRow().
 		Scan(&count)


### PR DESCRIPTION
This change is to update the Count function to generate `SELECT COUNT(*) ...` instead of `SELECT COUNT(__pet.*) ...`

We are in the process of updating an application at work and we noticed that the existing system was able to handle certain requests much faster than our new one. Upon further inspection we narrowed it down to a fairly simple count query being generated by kallax.

When kallax generates a count query, it includes the schema's alias in the `COUNT` function ever since a fix for [this](https://github.com/src-d/go-kallax/issues/205) issue was [merged](https://github.com/src-d/go-kallax/pull/208/files). For some reason, however, Postgres runs this query much slower than if it were just doing a `count(*)`. I'm even able to replicate this behavior using the `pets` schema used in kallax's tests/benchmarks.

```text
testing=# select count(*) from pets;
 count
--------
 204957
(1 row)

testing=# explain analyze SELECT COUNT(*) FROM pets __pet WHERE __pet.kind = 'cat';
                                                                QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=3913.86..3913.87 rows=1 width=8) (actual time=22.457..22.457 rows=1 loops=1)
   ->  Gather  (cost=3913.75..3913.86 rows=1 width=8) (actual time=22.384..22.454 rows=2 loops=1)
         Workers Planned: 1
         Workers Launched: 1
         ->  Partial Aggregate  (cost=2913.75..2913.76 rows=1 width=8) (actual time=19.289..19.289 rows=1 loops=2)
               ->  Parallel Seq Scan on pets __pet  (cost=0.00..2813.66 rows=40035 width=0) (actual time=0.020..15.464 rows=34160 loops=2)
                     Filter: (kind = 'cat'::text)
                     Rows Removed by Filter: 68319
 Planning time: 0.077 ms
 Execution time: 24.007 ms
(10 rows)

testing=# explain analyze SELECT COUNT(__pet.*) FROM pets __pet WHERE __pet.kind = 'cat';
                                                                 QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=3913.86..3913.87 rows=1 width=8) (actual time=28.419..28.419 rows=1 loops=1)
   ->  Gather  (cost=3913.75..3913.86 rows=1 width=8) (actual time=28.352..28.416 rows=2 loops=1)
         Workers Planned: 1
         Workers Launched: 1
         ->  Partial Aggregate  (cost=2913.75..2913.76 rows=1 width=8) (actual time=24.702..24.702 rows=1 loops=2)
               ->  Parallel Seq Scan on pets __pet  (cost=0.00..2813.66 rows=40035 width=43) (actual time=0.059..20.927 rows=34160 loops=2)
                     Filter: (kind = 'cat'::text)
                     Rows Removed by Filter: 68319
 Planning time: 0.080 ms
 Execution time: 29.979 ms
(10 rows)

testing=#
```

There is about a 5ms difference with just over 200k rows in the `pets` table. We were able to consistently see examples where `count(__x.*)` is 2 - 5 seconds slower than `count(*)` in our production databases.