### PR TITLE
Fix generate fields count report

### DIFF
--- a/generator/types.go
+++ b/generator/types.go
@@ -275,7 +275,7 @@ func (m *Model) String() string {
 		events = append(events, string(e))
 	}
 
-	return fmt.Sprintf("%q [%d Field(s)] [Events: %s]", m.Name, len(m.Fields), events)
+	return fmt.Sprintf("%q [%d Field(s)] [Events: %s]", m.Name, len(m.Fields)-1, events)
 }
 
 type occurrences map[string]uint

--- a/generator/types_test.go
+++ b/generator/types_test.go
@@ -345,6 +345,11 @@ func (s *ModelSuite) TestModelValidate() {
 	require.Error(m.Validate(), "should return error")
 }
 
+func (s *ModelSuite) TestString() {
+	s.Equal("\"Variadic\" [3 Field(s)] [Events: []]", s.variadic.String())
+	s.Equal("\"User\" [7 Field(s)] [Events: []]", s.model.String())
+}
+
 func TestFieldForeignKey(t *testing.T) {
 	r := require.New(t)
 	m := &Model{Name: "Foo", Table: "bar", Type: "foo.Foo"}


### PR DESCRIPTION
I think the report after generate is indicates a wrong number of fields. I don't know if the solution is a bit naive