### PR TITLE
Can we tag the latest changes in this project?

### DIFF
--- a/generator/cli/kallax/cmd.go
+++ b/generator/cli/kallax/cmd.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
-const version = "1.3.5"
+const version = "1.3.6"
 
 func main() {
 	if err := newApp().Run(os.Args); err != nil {

--- a/tests/kallax.go
+++ b/tests/kallax.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"time"
 
-	"gopkg.in/src-d/go-kallax.v1"
+	kallax "gopkg.in/src-d/go-kallax.v1"
 	"gopkg.in/src-d/go-kallax.v1/tests/fixtures"
 	"gopkg.in/src-d/go-kallax.v1/types"
 )


### PR DESCRIPTION
Opening this PR mostly in hopes of getting this project tagged. I'm relying on changes brought in from #291, however the previous tag (`v1.3.5`) is a few commits behind and I'd like to be able to pin my kallax dependency to a tag or version wildcard rather than a sha or master's HEAD.

Edit: also regenerating the tests with `go generate ./tests/...` to get failing build to pass. Looks like the generator is now generating the kallax import statement as `kallax "gopkg.in/src-d/go-kallax.v1"`. The diff was causing the build to fail.