### PR TITLE
Regenerating tests to get build to pass

### DIFF
--- a/tests/kallax.go
+++ b/tests/kallax.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"time"
 
-	"gopkg.in/src-d/go-kallax.v1"
+	kallax "gopkg.in/src-d/go-kallax.v1"
 	"gopkg.in/src-d/go-kallax.v1/tests/fixtures"
 	"gopkg.in/src-d/go-kallax.v1/types"
 )


### PR DESCRIPTION
Looks like the generator is generating the kallax import statement as `kallax "gopkg.in/src-d/go-kallax.v1"` now. The diff is causing the build to fail.