### PR TITLE
Add duration to debug proxy logger

### DIFF
--- a/store.go
+++ b/store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/lann/builder"
@@ -71,24 +72,32 @@ type proxyLogger struct {
 }
 
 func (p *proxyLogger) Exec(query string, args ...interface{}) (sql.Result, error) {
-	p.logger(fmt.Sprintf("kallax: Exec: %s", query), args...)
-	return p.DBProxyContext.Exec(query, args...)
+	start := time.Now()
+	result, err := p.DBProxyContext.Exec(query, args...)
+	p.logger(fmt.Sprintf("kallax: Exec: (%v) %s", time.Since(start), query), args...)
+	return result, err
 }
 
 func (p *proxyLogger) Query(query string, args ...interface{}) (*sql.Rows, error) {
-	p.logger(fmt.Sprintf("kallax: Query: %s", query), args...)
-	return p.DBProxyContext.Query(query, args...)
+	start := time.Now()
+	rows, err := p.DBProxyContext.Query(query, args...)
+	p.logger(fmt.Sprintf("kallax: Query: (%v) %s", time.Since(start), query), args...)
+	return rows, err
 }
 
 func (p *proxyLogger) QueryRow(query string, args ...interface{}) squirrel.RowScanner {
-	p.logger(fmt.Sprintf("kallax: QueryRow: %s", query), args...)
-	return p.DBProxyContext.QueryRow(query, args...)
+	start := time.Now()
+	rowScanner := p.DBProxyContext.QueryRow(query, args...)
+	p.logger(fmt.Sprintf("kallax: QueryRow: (%v) %s", time.Since(start), query), args...)
+	return rowScanner
 }
 
 func (p *proxyLogger) Prepare(query string) (*sql.Stmt, error) {
 	//If chained runner is a proxy, run Prepare(). Otherwise, noop.
-	p.logger(fmt.Sprintf("kallax: Prepare: %s", query))
-	return p.DBProxyContext.Prepare(query)
+	start := time.Now()
+	statement, err := p.DBProxyContext.Prepare(query)
+	p.logger(fmt.Sprintf("kallax: Prepare: (%v) %s", time.Since(start), query))
+	return statement, err
 }
 
 // PrepareContext will not be logged

--- a/store_test.go
+++ b/store_test.go
@@ -259,13 +259,8 @@ func (s *StoreSuite) TestDebugWith() {
 	s.store.DebugWith(logger).RawQuery("SELECT 1 + 1")
 	s.store.DebugWith(logger).RawExec("UPDATE foo SET bar = 1")
 
-	s.Equal(
-		queries,
-		[]string{
-			"kallax: Query: SELECT 1 + 1",
-			"kallax: Exec: UPDATE foo SET bar = 1",
-		},
-	)
+	s.Regexp("kallax: Query: \\(\\d+\\.\\d+.+\\) SELECT 1 \\+ 1", queries[0])
+	s.Regexp("kallax: Exec: \\(\\d+\\.\\d+.+\\) UPDATE foo SET bar = 1", queries[1])
 }
 
 func (s *StoreSuite) assertFound(rs ResultSet, expected ...string) {

--- a/store_test.go
+++ b/store_test.go
@@ -257,7 +257,7 @@ func (s *StoreSuite) TestDebugWith() {
 		queries = append(queries, q)
 	}
 	s.store.DebugWith(logger).RawQuery("SELECT 1 + 1")
-	s.store.DebugWith(logger).RawExec("UPDATE foo SET bar = 1")
+	s.store.DisableCacher().DebugWith(logger).RawExec("UPDATE foo SET bar = 1")
 
 	s.Regexp("kallax: Query: \\(\\d+\\.\\d+.+\\) SELECT 1 \\+ 1", queries[0])
 	s.Regexp("kallax: Exec: \\(\\d+\\.\\d+.+\\) UPDATE foo SET bar = 1", queries[1])


### PR DESCRIPTION
This logs the duration when using the proxy logger in debug mode.

Example with debug mode enabled:
```
2019/01/30 13:44:21 kallax: Query: (6.907795ms) SELECT __transaction.id, __transaction.guid, __transaction.date, ... IN ($1,$2) AND __transaction.user_guid IN ($3) LIMIT 1000, args: [false <nil> USR-123]
```

Tracking the duration is actually pretty fast considering we're executing db statements, but we're also opting in to a slower debug mode with extra logging, so we're choosing to pay the cost. I could have used a `defer func() { logTheThing }()` to make this code a little bit cleaner, but I didn't want to slow things down _too_ much.