### PR TITLE
Update Travis go/postgres to supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.9.x
-  - 1.10.x
+  - 1.13.x
+  - 1.14.x
   - tip
 
 matrix:
@@ -11,7 +11,7 @@ matrix:
     fast_finish: true
 
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
 
 env:
   - DBNAME=kallax_test DBUSER=postgres DBPASS='' GOPATH=/tmp/whatever:$GOPATH


### PR DESCRIPTION
With the recent golang 1.14 release, update the go matrix versions to
the most recent two versions as those are the only ones supported by the
upstream project (security wise, etc).

Also upgrade to the last 9.x version of Postgres as 9.4 ended support
recently.